### PR TITLE
Out 1705 | Update taxes and dates for created invoice

### DIFF
--- a/src/app/api/quickbooks/invoice/invoice.service.ts
+++ b/src/app/api/quickbooks/invoice/invoice.service.ts
@@ -190,7 +190,7 @@ export class InvoiceService extends BaseService {
           sparse: true,
         } as QBCustomerParseUpdatePayloadType
 
-        const customerRes = await intuitApi.parseUpdateCustomer(
+        const customerRes = await intuitApi.sparseUpdateCustomer(
           customerSparsePayload,
         )
         customer = customerRes.Customer
@@ -228,7 +228,8 @@ export class InvoiceService extends BaseService {
             Qty: lineItem.quantity,
             UnitPrice: actualAmount,
             TaxCodeRef: {
-              // required to enable tax for the product
+              // required to enable tax for the product.
+              // Doc reference: https://developer.intuit.com/app/developer/qbo/docs/workflows/manage-sales-tax-for-us-locales#specifying-sales-tax
               value: 'TAX',
             },
           },
@@ -249,10 +250,10 @@ export class InvoiceService extends BaseService {
         },
       }),
       ...(invoiceResource?.sentDate && {
-        TxnDate: dayjs(invoiceResource.sentDate).format('yyyy/MM/dd'),
+        TxnDate: dayjs(invoiceResource.sentDate).format('yyyy/MM/dd'), // Valid date format for TxnDate is yyyy/MM/dd. For more info: https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/invoice#the-invoice-object
       }),
       ...(invoiceResource?.dueDate && {
-        DueDate: dayjs(invoiceResource.dueDate).format('YYYY-MM-DD'),
+        DueDate: dayjs(invoiceResource.dueDate).format('YYYY-MM-DD'), // the date format for due date follows XML Schema standard (YYYY-MM-DD). For more info: https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/invoice#the-invoice-object
       }),
     }
 

--- a/src/app/api/quickbooks/invoice/invoice.service.ts
+++ b/src/app/api/quickbooks/invoice/invoice.service.ts
@@ -157,19 +157,10 @@ export class InvoiceService extends BaseService {
       CustomerRef: {
         value: customer.Id,
       },
-    }
-
-    // 5. create invoice in QB
-    const invoiceRes = await intuitApi.createInvoice(qbInvoicePayload)
-
-    // 6. update tax
-    const invoiceUpdateBody = {
+      // include tax and dates
       ...(invoiceResource?.taxAmount && {
         TxnTaxDetail: {
           TotalTax: Number((invoiceResource.taxAmount / 100).toFixed(2)),
-          TxnTaxCodeRef: {
-            value: 'TAX',
-          },
         },
       }),
       ...(invoiceResource?.sentDate && {
@@ -180,21 +171,8 @@ export class InvoiceService extends BaseService {
       }),
     }
 
-    if (Object.keys(invoiceUpdateBody).length > 0) {
-      const invoiceSparseUpdatePayload = {
-        Id: invoiceRes.Invoice.Id,
-        sparse: true,
-        SyncToken: invoiceRes.Invoice.SyncToken,
-        ...invoiceUpdateBody,
-      }
-
-      console.log({ invoiceSparseUpdatePayload })
-
-      const inv = await intuitApi.invoiceSparseUpdate(
-        invoiceSparseUpdatePayload,
-      )
-      console.log({ inv })
-    }
+    // 6. create invoice in QB
+    const invoiceRes = await intuitApi.createInvoice(qbInvoicePayload)
 
     const invoicePayload = {
       portalId: qbTokenInfo.intuitRealmId,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -23,7 +23,7 @@ export const intuitRedirectUri = apiUrl + process.env.INTUIT_REDIRECT_URI_PATH
 export const intuitEnvironment = (process.env.INTUIT_ENVIRONMENT ||
   'sandbox') as EnvironmentType
 export const intuitBaseUrl =
-  process.env.COPILOT_ENV === 'production'
+  intuitEnvironment === 'production'
     ? process.env.INTUIT_PRODUCTION_API_URL
     : process.env.INTUIT_SANDBOX_API_URL
 export const intuitApiMinorVersion =

--- a/src/type/dto/intuitAPI.dto.ts
+++ b/src/type/dto/intuitAPI.dto.ts
@@ -27,7 +27,7 @@ export type QBInvoiceCreatePayloadType = z.infer<
 
 export const QBInvoiceSparseUpdatePayloadSchema = z.object({
   Id: z.string(),
-  sparse: z.boolean(),
+  sparse: z.literal(true),
   SyncToken: z.string(),
   TxnTaxDetail: z
     .object({

--- a/src/type/dto/intuitAPI.dto.ts
+++ b/src/type/dto/intuitAPI.dto.ts
@@ -25,6 +25,23 @@ export type QBInvoiceCreatePayloadType = z.infer<
   typeof QBInvoiceCreatePayloadSchema
 >
 
+export const QBInvoiceSparseUpdatePayloadSchema = z.object({
+  Id: z.string(),
+  sparse: z.boolean(),
+  SyncToken: z.string(),
+  TxnTaxDetail: z
+    .object({
+      TotalTax: z.number(),
+    })
+    .optional(),
+  TxnDate: z.string().optional(),
+  DueDate: z.string().optional(),
+})
+
+export type QBInvoiceSparseUpdatePayloadType = z.infer<
+  typeof QBInvoiceSparseUpdatePayloadSchema
+>
+
 export const QBCustomerCreatePayloadSchema = z.object({
   GivenName: z.string(),
   FamilyName: z.string(),

--- a/src/type/dto/webhook.dto.ts
+++ b/src/type/dto/webhook.dto.ts
@@ -32,6 +32,10 @@ export const InvoiceCreatedResponseSchema = z.object({
     recipientId: z.string(),
     status: z.nativeEnum(InvoiceStatus),
     total: z.number(),
+    taxAmount: z.number().optional(),
+    taxPercentage: z.number().min(0).max(100).optional(),
+    sentDate: z.string().nullish(),
+    dueDate: z.string().nullish(),
   }),
 })
 

--- a/src/type/dto/webhook.dto.ts
+++ b/src/type/dto/webhook.dto.ts
@@ -33,9 +33,8 @@ export const InvoiceCreatedResponseSchema = z.object({
     status: z.nativeEnum(InvoiceStatus),
     total: z.number(),
     taxAmount: z.number().optional(),
-    taxPercentage: z.number().min(0).max(100).optional(),
-    sentDate: z.string().nullish(),
-    dueDate: z.string().nullish(),
+    sentDate: z.string().datetime().nullish(),
+    dueDate: z.string().datetime().nullish(),
   }),
 })
 

--- a/src/utils/intuitAPI.ts
+++ b/src/utils/intuitAPI.ts
@@ -5,6 +5,7 @@ import { getFetcher, postFetcher } from '@/helper/fetch.helper'
 import {
   QBCustomerCreatePayloadType,
   QBInvoiceCreatePayloadType,
+  QBInvoiceSparseUpdatePayloadType,
 } from '@/type/dto/intuitAPI.dto'
 
 export type IntuitAPITokensType = Pick<
@@ -42,7 +43,7 @@ export default class IntuitAPI {
     return response
   }
 
-  private async manualGETFetch(
+  private async manualGetFetch(
     url: string,
     customHeaders?: Record<string, string>,
   ) {
@@ -57,7 +58,7 @@ export default class IntuitAPI {
   async _customQuery(query: string) {
     console.log('IntuitAPI#customQuery')
     const url = `${intuitBaseUrl}/v3/company/${IntuitAPI.tokens.intuitRealmId}/query?query=${query}&minorversion=${intuitApiMinorVersion}`
-    return await this.manualGETFetch(url)
+    return await this.manualGetFetch(url)
   }
 
   async _createInvoice(payload: QBInvoiceCreatePayloadType) {
@@ -82,6 +83,17 @@ export default class IntuitAPI {
     return customer
   }
 
+  async _invoiceSparseUpdate(payload: QBInvoiceSparseUpdatePayloadType) {
+    console.log('IntuitAPI#InvoiceSparseUpdate | invoice sparse update start')
+    const url = `${intuitBaseUrl}/v3/company/${IntuitAPI.tokens.intuitRealmId}/invoice?minorversion=${intuitApiMinorVersion}`
+    const invoice = await this.manualPostFetch(url, payload)
+    console.log(
+      'IntuitAPI#InvoiceSparseUpdate | invoice sparse updated for doc number=',
+      invoice?.Invoice.DocNumber,
+    )
+    return invoice
+  }
+
   private wrapWithRetry<Args extends unknown[], R>(
     fn: (...args: Args) => Promise<R>,
   ): (...args: Args) => Promise<R> {
@@ -91,4 +103,5 @@ export default class IntuitAPI {
   customQuery = this.wrapWithRetry(this._customQuery)
   createInvoice = this.wrapWithRetry(this._createInvoice)
   createCustomer = this.wrapWithRetry(this._createCustomer)
+  invoiceSparseUpdate = this.wrapWithRetry(this._invoiceSparseUpdate)
 }

--- a/src/utils/intuitAPI.ts
+++ b/src/utils/intuitAPI.ts
@@ -31,7 +31,16 @@ export default class IntuitAPI {
     }
   }
 
-  private async manualPostFetch(
+  /**
+   * This function is used to make a POST request to Intuit API with necessary authorization headers
+   *
+   * @private
+   * @async
+   * @param {string} url
+   * @param {Record<string, any>} body
+   * @param {?Record<string, string>} [customHeaders]
+   */
+  private async postFetchWithHeaders(
     url: string,
     body: Record<string, any>,
     customHeaders?: Record<string, string>,
@@ -44,7 +53,15 @@ export default class IntuitAPI {
     return response
   }
 
-  private async manualGetFetch(
+  /**
+   * This function is used to make a GET request to Intuit API with necessary authorization headers
+   *
+   * @private
+   * @async
+   * @param {string} url
+   * @param {?Record<string, string>} [customHeaders]
+   */
+  private async getFetchWithHeader(
     url: string,
     customHeaders?: Record<string, string>,
   ) {
@@ -59,13 +76,13 @@ export default class IntuitAPI {
   async _customQuery(query: string) {
     console.log('IntuitAPI#customQuery')
     const url = `${intuitBaseUrl}/v3/company/${IntuitAPI.tokens.intuitRealmId}/query?query=${query}&minorversion=${intuitApiMinorVersion}`
-    return await this.manualGetFetch(url)
+    return await this.getFetchWithHeader(url)
   }
 
   async _createInvoice(payload: QBInvoiceCreatePayloadType) {
     console.log('IntuitAPI#createInvoice | invoice creation start')
     const url = `${intuitBaseUrl}/v3/company/${IntuitAPI.tokens.intuitRealmId}/invoice?minorversion=${intuitApiMinorVersion}`
-    const invoice = await this.manualPostFetch(url, payload)
+    const invoice = await this.postFetchWithHeaders(url, payload)
     console.log(
       'IntuitAPI#createInvoice | invoice created with doc number=',
       invoice?.Invoice?.DocNumber,
@@ -76,7 +93,7 @@ export default class IntuitAPI {
   async _createCustomer(payload: QBCustomerCreatePayloadType) {
     console.log('IntuitAPI#createCustomer | customer creation start')
     const url = `${intuitBaseUrl}/v3/company/${IntuitAPI.tokens.intuitRealmId}/customer?minorversion=${intuitApiMinorVersion}`
-    const customer = await this.manualPostFetch(url, payload)
+    const customer = await this.postFetchWithHeaders(url, payload)
     console.log(
       'IntuitAPI#createCustomer | customer created with name=',
       customer?.Customer?.FullyQualifiedName,
@@ -87,7 +104,7 @@ export default class IntuitAPI {
   async _invoiceSparseUpdate(payload: QBInvoiceSparseUpdatePayloadType) {
     console.log('IntuitAPI#InvoiceSparseUpdate | invoice sparse update start')
     const url = `${intuitBaseUrl}/v3/company/${IntuitAPI.tokens.intuitRealmId}/invoice?minorversion=${intuitApiMinorVersion}`
-    const invoice = await this.manualPostFetch(url, payload)
+    const invoice = await this.postFetchWithHeaders(url, payload)
     console.log(
       'IntuitAPI#InvoiceSparseUpdate | invoice sparse updated for doc number=',
       invoice?.Invoice.DocNumber,
@@ -95,13 +112,13 @@ export default class IntuitAPI {
     return invoice
   }
 
-  async _parseUpdateCustomer(payload: QBCustomerParseUpdatePayloadType) {
-    console.log('IntuitAPI#parseUpdateCustomer | customer sparse update start')
+  async _sparseUpdateCustomer(payload: QBCustomerParseUpdatePayloadType) {
+    console.log('IntuitAPI#sparseUpdateCustomer | customer sparse update start')
     const url = `${intuitBaseUrl}/v3/company/${IntuitAPI.tokens.intuitRealmId}/customer?minorversion=${intuitApiMinorVersion}`
-    const customer = await this.manualPostFetch(url, payload)
+    const customer = await this.postFetchWithHeaders(url, payload)
 
     console.log(
-      'IntuitAPI#parseUpdateCustomer | customer sparse updated with name=',
+      'IntuitAPI#sparseUpdateCustomer | customer sparse updated with name=',
       customer?.Customer?.FullyQualifiedName,
     )
     return customer
@@ -117,5 +134,5 @@ export default class IntuitAPI {
   createInvoice = this.wrapWithRetry(this._createInvoice)
   createCustomer = this.wrapWithRetry(this._createCustomer)
   invoiceSparseUpdate = this.wrapWithRetry(this._invoiceSparseUpdate)
-  parseUpdateCustomer = this.wrapWithRetry(this._parseUpdateCustomer)
+  sparseUpdateCustomer = this.wrapWithRetry(this._sparseUpdateCustomer)
 }


### PR DESCRIPTION
## Changes

- [X] tax include in invoice sparse update
- [X] format and include sentDate and dueDate

## Testing Criteria

- [X] Showing the inclusion of tax amount [Loom](https://www.loom.com/share/c1ee86b82b5442b89fc78fd409b3650d?sid=605678f1-de7e-47bb-9d43-918ee499ef3e) 

- [X] Image showing the tax reflected invoice
![invoice screenshot in QB invoice](https://github.com/user-attachments/assets/566187e8-b4c5-4425-bc4f-61168d6e2ae3)

## Notes

- No need to use sparse invoice update to include tax info. Directly included in invoice create. For tax to get included, need to [Turn on the sales tax](https://developer.intuit.com/app/developer/qbo/docs/workflows/manage-sales-tax-for-us-locales#specifying-sales-tax) in QB account. Also the sales tax engine doesn't work on sandbox environment. [Learn more](https://developer.intuit.com/app/developer/qbo/docs/workflows/manage-sales-tax-for-us-locales). 
