### PR TITLE
OUT-1825 |  Income account reference empty when re-authorization

### DIFF
--- a/src/app/api/quickbooks/auth/auth.service.ts
+++ b/src/app/api/quickbooks/auth/auth.service.ts
@@ -84,6 +84,9 @@ export class AuthService extends BaseService {
         // query income acc ref from intuit
         const incomeAccRef = await intuitApi.getSingleIncomeAccount()
         insertPayload.incomeAccountRef = incomeAccRef.Id
+      } else {
+        // case for re-authorization
+        insertPayload.incomeAccountRef = existingToken.incomeAccountRef // if exists, use existing income account ref
       }
 
       const qbTokens = await tokenService.upsertQBToken(insertPayload, ['id'])


### PR DESCRIPTION
## Changes

- [X] fixed issue related to empty incomeAccountRef when re-authorization

## Testing Criteria

[Loom](https://www.loom.com/share/3b050feedaad4a3cb8a1ed6d13e421ae?sid=36366d75-b277-4581-89a3-785f202453f9)