### PR TITLE
OUT-1835 | Implementation for void invoices and sync in QB

### DIFF
--- a/src/app/api/core/types/webhook.ts
+++ b/src/app/api/core/types/webhook.ts
@@ -4,4 +4,5 @@ export enum WebhookEvents {
   PRODUCT_CREATED = 'product.created',
   PRICE_CREATED = 'price.created',
   INVOICE_PAID = 'invoice.paid',
+  INVOICE_VOIDED = 'invoice.voided',
 }

--- a/src/app/api/quickbooks/webhook/webhook.service.ts
+++ b/src/app/api/quickbooks/webhook/webhook.service.ts
@@ -135,6 +135,22 @@ export class WebhookService extends BaseService {
         )
         break
 
+      case WebhookEvents.INVOICE_VOIDED:
+        const parsedVoidedInvoice = InvoicePaidResponseSchema.safeParse(payload)
+        if (!parsedVoidedInvoice.success || !parsedVoidedInvoice.data) {
+          console.error(
+            'WebhookService#handleWebhookEvent | Could not parse invoice paid response',
+          )
+          break
+        }
+        const parsedVoidedInvoiceResource = parsedVoidedInvoice.data
+        const invoiceServce = new InvoiceService(this.user)
+        await invoiceServce.webhookInvoiceVoided(
+          parsedVoidedInvoiceResource,
+          qbTokenInfo,
+        )
+        break
+
       default:
         console.error('WebhookService#handleWebhookEvent | Unknown event type')
     }

--- a/src/type/dto/intuitAPI.dto.ts
+++ b/src/type/dto/intuitAPI.dto.ts
@@ -113,3 +113,12 @@ export const QBPaymentCreatePayloadSchema = z.object({
 export type QBPaymentCreatePayloadType = z.infer<
   typeof QBPaymentCreatePayloadSchema
 >
+
+export const QBVoidInvoicePayloadSchema = z.object({
+  Id: z.string(),
+  SyncToken: z.string(),
+})
+
+export type QBVoidInvoicePayloadType = z.infer<
+  typeof QBVoidInvoicePayloadSchema
+>


### PR DESCRIPTION
## Changes

- [X] listen to void invoices and sync in QB
- [X] update the status to 'void' in our sync table
- [X] only void invoice with "open" status

## Testing Criteria

[Loom](https://www.loom.com/share/28c47002dd564982b5295b04685fc31f)