### PR TITLE
OUT-1862 | Description for productized line item in QB not being …

### DIFF
--- a/src/app/api/quickbooks/invoice/invoice.service.ts
+++ b/src/app/api/quickbooks/invoice/invoice.service.ts
@@ -32,6 +32,11 @@ const oneOffItem = {
   value: '1',
 }
 
+type InvoiceItemRefAndDescriptionType = {
+  ref: QBNameValueSchemaType
+  productDescription?: string
+}
+
 export class InvoiceService extends BaseService {
   private copilot: CopilotAPI
 
@@ -83,7 +88,7 @@ export class InvoiceService extends BaseService {
     productId: string,
     priceId: string,
     intuitApi: IntuitAPI,
-  ): Promise<QBNameValueSchemaType> {
+  ): Promise<InvoiceItemRefAndDescriptionType> {
     const productService = new ProductService(this.user)
     const mapping = await productService.getMappingByProductPriceId(
       productId,
@@ -93,12 +98,13 @@ export class InvoiceService extends BaseService {
       if (mapping.isExcluded) {
         // if excluded, do not include in invoice and send as one-off item
         console.info('InvoiceService#getInvoiceItemRef | Product is excluded')
-        return oneOffItem
+        return { ref: oneOffItem }
       }
       if (mapping.qbItemId) {
         console.info('InvoiceService#getInvoiceItemRef | Product map found')
         return {
-          value: mapping.qbItemId,
+          ref: { value: mapping.qbItemId },
+          productDescription: mapping.description || '',
         }
       }
     }
@@ -145,7 +151,7 @@ export class InvoiceService extends BaseService {
     }
     await productService.createQBProduct(productMappingPayload)
 
-    return { value: qbItem.Id }
+    return { ref: { value: qbItem.Id }, productDescription }
   }
 
   async prepareLineItemPayload(
@@ -154,7 +160,11 @@ export class InvoiceService extends BaseService {
   ) {
     const actualAmount = lineItem.amount / 100 // Convert to dollar. amount received in cents.
 
-    let itemRef: QBNameValueSchemaType = oneOffItem
+    let itemRef: InvoiceItemRefAndDescriptionType = {
+      ref: oneOffItem,
+      productDescription: lineItem.description,
+    }
+
     if (lineItem.productId && lineItem.priceId) {
       itemRef = await this.getInvoiceItemRef(
         lineItem.productId,
@@ -166,7 +176,7 @@ export class InvoiceService extends BaseService {
       DetailType: 'SalesItemLineDetail',
       Amount: actualAmount * lineItem.quantity,
       SalesItemLineDetail: {
-        ItemRef: itemRef,
+        ItemRef: itemRef.ref,
         Qty: lineItem.quantity,
         UnitPrice: actualAmount,
         TaxCodeRef: {
@@ -175,7 +185,10 @@ export class InvoiceService extends BaseService {
           value: 'TAX',
         },
       },
-      Description: lineItem.description,
+      Description:
+        typeof itemRef.productDescription === 'undefined'
+          ? lineItem.description
+          : itemRef.productDescription, // specific check for undefined type. Allow empty string
     }
   }
 

--- a/src/app/api/quickbooks/product/product.service.ts
+++ b/src/app/api/quickbooks/product/product.service.ts
@@ -221,6 +221,7 @@ export class ProductService extends BaseService {
     const prices = await copilot.getPrices(product.id)
     return (prices?.data ?? []).map((price) => ({
       ...product,
+      description: convert(product.description),
       priceId: price.id,
       amount: price.amount,
       type: price.type,

--- a/src/hook/useSettings.ts
+++ b/src/hook/useSettings.ts
@@ -22,6 +22,7 @@ export type ProductDataType = {
   name: string
   price: string
   priceId: string
+  description?: string
 }
 
 export type QBItemDataType = {
@@ -124,6 +125,7 @@ export const useProductMappingSettings = () => {
         return {
           ...mapItem,
           name: item.name || null,
+          description: products[index].description || null,
           priceId: products[index].priceId,
           productId: products[index].id,
           unitPrice: item.numericPrice?.toString() || null,
@@ -198,6 +200,7 @@ export const useProductTableSetting = (
         newMap = products?.products?.map((product: ProductDataType) => {
           return {
             name: null,
+            description: product.description,
             priceId: product.priceId,
             productId: product.id,
             unitPrice: null,
@@ -219,6 +222,7 @@ export const useProductTableSetting = (
             // if found, return with the mapped product in mapping item
             return {
               name: mappedItem.name,
+              description: mappedItem.description,
               priceId: product.priceId,
               productId: product.id,
               unitPrice: mappedItem.unitPrice,
@@ -229,6 +233,7 @@ export const useProductTableSetting = (
           }
           return {
             name: null,
+            description: null,
             priceId: product.priceId,
             productId: product.id,
             unitPrice: null,
@@ -257,6 +262,7 @@ export const useProductTableSetting = (
           return {
             id: product.id,
             name: product.name,
+            description: product.description || '',
             price: newPrice,
             numericPrice: product.amount,
             priceId: product.priceId,


### PR DESCRIPTION
## Changes

- [X] For mapped products: include description of product during invoice creation in QB. If no description, send blank or empty
- [X] For unmapped products: include product name as description during invoice creation.
- [X] Add the description of product in product mapping table while mapping process.

## Testing Criteria

Mapped products

![image](https://github.com/user-attachments/assets/401c55ec-9d81-45b1-9a32-a946df2cebb5)

QB invoice

![image](https://github.com/user-attachments/assets/3893f336-b716-44ad-998f-7982909e0395)

When used rich text formatting for description

![image](https://github.com/user-attachments/assets/79f13c59-9e10-4b22-9636-e183d0606b78)

