### PR TITLE
Out 1919 | FE: Integrate sync history download API

### DIFF
--- a/src/hook/useQuickbooks.ts
+++ b/src/hook/useQuickbooks.ts
@@ -224,7 +224,21 @@ export const useAppBridge = (token: string, isEnabled: boolean | null) => {
     }
   }
 
+  const downloadCsvAction = async () => {
+    const url = `/api/quickbooks/syncLog/download?token=${token}`
+    const link = document.createElement('a')
+    link.href = url
+    link.download = 'sync-history.csv'
+    document.body.appendChild(link)
+    link.click()
+    link.remove()
+  }
+
   const actions = [
+    {
+      label: 'Download sync history',
+      onClick: downloadCsvAction,
+    },
     {
       label: 'Disconnect app',
       onClick: disconnectAction,


### PR DESCRIPTION
## Changes

- [X] added "Download Sync History" option in overflow menu of app bridge

## Testing Criteria

[Loom](https://www.loom.com/share/1bdb24d2f392463194216ab82fd54e7b?sid=5419e847-9efd-4023-b2dc-d7df5a5032db)
