### PR TITLE
OUT-1980: Invoice assigned to company are not syncing to QB

### DIFF
--- a/src/app/api/quickbooks/customer/customer.service.ts
+++ b/src/app/api/quickbooks/customer/customer.service.ts
@@ -17,13 +17,13 @@ import httpStatus from 'http-status'
 
 type ClientCompanyType = {
   id: string
-  givenName?: string
-  familyName?: string
+  givenName: string
+  familyName: string
   companyId: string
-  email?: string
+  email: string
   displayName: string
   type: 'client' | 'company'
-  companyName?: string
+  companyName: string
 }
 
 export class CustomerService extends BaseService {
@@ -95,6 +95,10 @@ export class CustomerService extends BaseService {
       companyId: '',
       displayName: '',
       type: 'client',
+      email: '',
+      givenName: '',
+      familyName: '',
+      companyName: '',
     }
 
     let client = await copilot.getClient(recipientId)
@@ -140,20 +144,21 @@ export class CustomerService extends BaseService {
           ...clientCompany,
           familyName: client.familyName,
           givenName: client.givenName,
-          displayName: client.givenName + ' ' + client.familyName,
+          displayName: `${client.givenName} ${client.familyName} (${company.name})`,
           type: 'client' as const,
-          email: client.email,
+          email: client.email || '',
           companyId: company.id,
           companyName: company.name,
         }
       }
+      return { recipientInfo: clientCompany, companyInfo: company }
     }
     return {
       recipientInfo: {
         ...clientCompany,
         familyName: client?.familyName || '',
         givenName: client?.givenName || '',
-        displayName: client?.givenName + ' ' + client?.familyName,
+        displayName: `${client?.givenName} ${client?.familyName}`,
         type: 'client' as const,
         email: client?.email || '',
         companyId: client?.companyId || '',

--- a/src/app/api/quickbooks/invoice/invoice.service.ts
+++ b/src/app/api/quickbooks/invoice/invoice.service.ts
@@ -339,7 +339,7 @@ export class InvoiceService extends BaseService {
       }
       if (existingCustomer.email !== recipientInfo.email) {
         sparseUpdatePayload.PrimaryEmailAddr = {
-          Address: recipientInfo?.email || '',
+          Address: recipientInfo.email,
         }
       }
       if (Object.keys(sparseUpdatePayload).length > 0) {
@@ -475,7 +475,7 @@ export class InvoiceService extends BaseService {
         },
         {
           displayName: recipientInfo.displayName,
-          email: recipientInfo.email,
+          email: recipientInfo?.email || null,
         },
       )
     }


### PR DESCRIPTION
## Changes

- when company name setting flag is false and invoice billed to company then customer will be create in QB as follows: customer name (company name)
- if the company name setting flag is true, customer is created/updated using company name

## Testing Criteria

![image (1)](https://github.com/user-attachments/assets/7f2689a8-9b51-4847-821e-8b2a65c8ce0d)
