### PR TITLE
OUT-1968 | OUT-1978 | OUT-1930: Clean up dropdown list and font size change

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,8 +9,13 @@
 @theme {
   --color-card-divider: #ededf0;
   --color-gray-100: #f8f9fb;
+  --color-gray-150: #eff1f4;
   --color-gray-200: #dfe1e4;
   --color-gray-500: #6b6f76; /** secondary */
   --color-gray-600: #212b36; /** primary */
   --color-blue-300: #0c41bb;
+  --shadow-popover-050: 0px 6px 20px 0px rgba(0, 0, 0, 0.07);
+  --text-body-micro: 10px;
+  --text-body-xs: 12px;
+  --leading-body-micro: 18px;
 }

--- a/src/components/dashboard/settings/sections/product/ProductMappingTable.tsx
+++ b/src/components/dashboard/settings/sections/product/ProductMappingTable.tsx
@@ -17,9 +17,9 @@ const MapItemComponent = ({
   return (
     <>
       {currentlyMapped ? (
-        <div className="space-y-1 text-left">
-          <div className="text-sm">{currentlyMapped?.name}</div>
-          <div className="text-sm text-gray-500">
+        <div className="text-left">
+          <div className="text-sm leading-5">{currentlyMapped?.name}</div>
+          <div className="text-body-xs leading-5 text-gray-500">
             {currentlyMapped.unitPrice &&
               `$${parseInt(currentlyMapped.unitPrice) / 100}`}
           </div>

--- a/src/components/dashboard/settings/sections/product/ProductMappingTable.tsx
+++ b/src/components/dashboard/settings/sections/product/ProductMappingTable.tsx
@@ -108,7 +108,7 @@ export default function ProductMappingTable({
                   </td>
 
                   {/* QuickBooks Items Column */}
-                  <td className="py-2 pl-4 pr-3 border-l border-gray-200 bg-gray-150 hover:bg-gray-50 relative">
+                  <td className="py-2 pl-4 pr-3 border-l border-gray-200 bg-gray-100 hover:bg-gray-150 relative">
                     <button
                       onClick={() => toggleDropdown(index)}
                       className="w-full h-full flex items-center justify-between transition-colors"
@@ -149,9 +149,9 @@ export default function ProductMappingTable({
                             className="w-full text-sm focus:outline-none focus:ring-1 focus:ring-gray-500 focus:border-gray-500"
                           />
                         </div>
-                        <div className="px-3 py-2 border-t-1 border-b-1 border-card-divider">
+                        <div className="border-t-1 border-b-1 border-card-divider hover:bg-gray-100">
                           <button
-                            className="text-sm text-gray-600 cursor-pointer"
+                            className="w-full h-full text-left  px-3 py-2 text-sm text-gray-600 cursor-pointer"
                             onClick={() => selectItem(index, {}, products)}
                           >
                             Exclude from mapping
@@ -176,7 +176,7 @@ export default function ProductMappingTable({
                                       products,
                                     )
                                   }
-                                  className="w-full flex items-center justify-between px-3 py-1.5 text-sm hover:bg-gray-50 transition-colors cursor-pointer text-left"
+                                  className="w-full flex items-center justify-between px-3 py-1.5 text-sm hover:bg-gray-100 transition-colors cursor-pointer text-left"
                                 >
                                   <span className="text-gray-600 line-clamp-1">
                                     {item.name}

--- a/src/components/dashboard/settings/sections/product/ProductMappingTable.tsx
+++ b/src/components/dashboard/settings/sections/product/ProductMappingTable.tsx
@@ -2,7 +2,6 @@ import { ProductMappingComponentType } from '@/components/dashboard/settings/sec
 import { ProductMappingItemType } from '@/db/schema/qbProductSync'
 import { useMapItem, useProductTableSetting } from '@/hook/useSettings'
 import DropDownIcon from '@/components/ui/DropDownIcon'
-import { excerpt } from '@/utils/string'
 import { Icon, Spinner } from 'copilot-design-system'
 
 const MapItemComponent = ({
@@ -85,12 +84,14 @@ export default function ProductMappingTable({
               </tr>
             ) : products ? (
               products.map((product, index) => (
-                <tr key={index} className="hover:bg-gray-50 transition-colors">
+                <tr key={index} className="transition-colors">
                   {/* Copilot Products Column */}
                   <td className="py-2 pl-4 pr-3">
                     <div className="">
-                      <div className="text-sm leading-5">{product.name}</div>
-                      <div className="text-sm leading-5 text-gray-500">
+                      <div className="text-sm leading-5 text-gray-600">
+                        {product.name}
+                      </div>
+                      <div className="text-body-xs leading-5 text-gray-500">
                         {product.price}
                       </div>
                     </div>
@@ -107,10 +108,10 @@ export default function ProductMappingTable({
                   </td>
 
                   {/* QuickBooks Items Column */}
-                  <td className="py-2 pl-4 pr-3 border-l border-gray-200 bg-gray-100 relative">
+                  <td className="py-2 pl-4 pr-3 border-l border-gray-200 bg-gray-150 hover:bg-gray-50 relative">
                     <button
                       onClick={() => toggleDropdown(index)}
-                      className="w-full h-full flex items-center justify-between hover:bg-gray-50 transition-colors"
+                      className="w-full h-full flex items-center justify-between transition-colors"
                     >
                       {selectedItems[index] &&
                       Object.keys(selectedItems[index]).length > 0 ? (
@@ -136,7 +137,7 @@ export default function ProductMappingTable({
                     </button>
 
                     {openDropdowns[index] && (
-                      <div className="absolute right-0 left-[-145px] top-full md:left-0 md:right-0 bg-white border border-gray-200 shadow-xl rounded-sm z-100 md:min-w-[320px]">
+                      <div className="absolute right-[-1px] left-[-145px] top-full mt-[-4px] md:left-[-1px] bg-white border border-gray-150 !shadow-popover-050 rounded-sm z-100 md:min-w-[320px]">
                         <div className="px-3 py-2">
                           <input
                             type="text"
@@ -148,15 +149,15 @@ export default function ProductMappingTable({
                             className="w-full text-sm focus:outline-none focus:ring-1 focus:ring-gray-500 focus:border-gray-500"
                           />
                         </div>
-                        <div className="px-3 py-2 border-1 border-card-divider">
+                        <div className="px-3 py-2 border-t-1 border-b-1 border-card-divider">
                           <button
-                            className="text-sm text-gray-700 cursor-pointer"
+                            className="text-sm text-gray-600 cursor-pointer"
                             onClick={() => selectItem(index, {}, products)}
                           >
                             Exclude from mapping
                           </button>
                         </div>
-                        <div className="max-h-64 overflow-y-auto">
+                        <div className="max-h-56 overflow-y-auto">
                           {quickbooksItems &&
                             getFilteredItems(index, quickbooksItems).map(
                               (item, itemIndex) => (
@@ -177,8 +178,10 @@ export default function ProductMappingTable({
                                   }
                                   className="w-full flex items-center justify-between px-3 py-1.5 text-sm hover:bg-gray-50 transition-colors cursor-pointer text-left"
                                 >
-                                  <span>{excerpt(item.name, 65)}</span>
-                                  <span className="text-gray-500">
+                                  <span className="text-gray-600 line-clamp-1">
+                                    {item.name}
+                                  </span>
+                                  <span className="text-gray-500 text-body-micro leading-body-micro">
                                     {item.price}
                                   </span>
                                 </button>

--- a/src/components/dashboard/settings/sections/product/ProductMappingTable.tsx
+++ b/src/components/dashboard/settings/sections/product/ProductMappingTable.tsx
@@ -116,10 +116,10 @@ export default function ProductMappingTable({
                       {selectedItems[index] &&
                       Object.keys(selectedItems[index]).length > 0 ? (
                         <div className="text-left">
-                          <div className="text-sm">
+                          <div className="text-sm leading-5">
                             {selectedItems[index].name}
                           </div>
-                          <div className="text-sm text-gray-500">
+                          <div className="text-body-xs leading-5 text-gray-500">
                             {selectedItems[index].price}
                           </div>
                         </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,15 +6,7 @@ const config: Config = {
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
-  theme: {
-    extend: {
-      backgroundImage: {
-        'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
-        'gradient-conic':
-          'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
-      },
-    },
-  },
+  theme: {},
   plugins: [],
 }
 export default config


### PR DESCRIPTION
## Changes

- changed dropdown list border color
- added box shadow in dropdown list
- overlap dropdown border with cell border
- change font color and sizes
- tailwind css line-clamp for longer product name (excerpt text)
- update the hover effect only for QB items column

## Testing criteria

- Dropdown styles
![image](https://github.com/user-attachments/assets/130ffebb-1cd1-446c-a7cc-33b6c4df8ea3)

- Hover states 
![image](https://github.com/user-attachments/assets/cb7dfea3-f030-4986-9d15-770bbbef1d2d)
