### PR TITLE
OUT-1958: Hide the action menu when the app is disconnected

### DIFF
--- a/src/app/(home)/HomeClient.tsx
+++ b/src/app/(home)/HomeClient.tsx
@@ -13,7 +13,11 @@ export default function HomeClient() {
     useQuickbooks(token, tokenPayload, reconnect)
 
   // bridge related logics like disconnect app and download sync log csv
-  useAppBridge(token, isEnabled)
+  useAppBridge({
+    token,
+    isEnabled,
+    connectionStatus: hasConnection || portalConnectionStatus,
+  })
 
   if (hasConnection === null) {
     return (

--- a/src/components/dashboard/settings/sections/product/ProductMappingTable.tsx
+++ b/src/components/dashboard/settings/sections/product/ProductMappingTable.tsx
@@ -114,7 +114,7 @@ export default function ProductMappingTable({
                   <td className="border-l border-gray-200 bg-gray-100 hover:bg-gray-150 relative">
                     <button
                       onClick={() => toggleDropdown(index)}
-                      className="w-full h-full grid grid-cols-6 md:grid-cols-14 hover:bg-gray-50 transition-colors py-2 pl-4 pr-3"
+                      className="w-full h-full grid grid-cols-6 md:grid-cols-14 transition-colors py-2 pl-4 pr-3"
                     >
                       <div className="col-span-5 md:col-span-13 text-left">
                         {selectedItems[index] &&

--- a/src/hook/useQuickbooks.ts
+++ b/src/hook/useQuickbooks.ts
@@ -216,15 +216,21 @@ export const useQuickbooksCallback = () => {
   return { loading, error }
 }
 
-export const useAppBridge = (token: string, isEnabled: boolean | null) => {
+export const useAppBridge = ({
+  token,
+  isEnabled,
+  connectionStatus,
+}: {
+  token: string
+  isEnabled: boolean | null
+  connectionStatus: boolean
+}) => {
   const disconnectAction = async () => {
-    if (isEnabled) {
-      const payload = {
-        enable: false,
-      }
-      const url = `/api/quickbooks/token/change-enable-status?token=${token}`
-      await postFetcher(url, {}, payload)
+    const payload = {
+      enable: false,
     }
+    const url = `/api/quickbooks/token/change-enable-status?token=${token}`
+    await postFetcher(url, {}, payload)
   }
 
   const downloadCsvAction = async () => {
@@ -236,16 +242,21 @@ export const useAppBridge = (token: string, isEnabled: boolean | null) => {
     link.click()
     link.remove()
   }
+  let actions: { label: string; onClick: () => Promise<void> }[] = []
+  if (connectionStatus) {
+    actions = [
+      {
+        label: 'Download sync history',
+        onClick: downloadCsvAction,
+      },
+    ]
 
-  const actions = [
-    {
-      label: 'Download sync history',
-      onClick: downloadCsvAction,
-    },
-    {
-      label: 'Disconnect app',
-      onClick: disconnectAction,
-    },
-  ]
+    if (isEnabled) {
+      actions.push({
+        label: 'Disconnect app',
+        onClick: disconnectAction,
+      })
+    }
+  }
   useActionsMenu(actions)
 }


### PR DESCRIPTION
## Changes

- [X] When the app is not connected, hide all action menus.
- [X] When the app is connected but not enabled, hide the "Disconnect app" menu.

## Testing Criteria

- When the app is not connected
![image](https://github.com/user-attachments/assets/5e74c6e5-84ff-44ae-93de-c0a886b5c56c)

- When the app is not enabled
![image](https://github.com/user-attachments/assets/05b738a8-97b5-49ff-8ed0-0c9f42796b4f)

- When the app is connected and enabled
![image](https://github.com/user-attachments/assets/45c7b5c7-a523-4034-810a-045cea62104d)