### PR TITLE
OUT-2107: Close the list by clicking on a QB item cell a second time

### DIFF
--- a/src/components/dashboard/settings/sections/product/ProductMappingTable.tsx
+++ b/src/components/dashboard/settings/sections/product/ProductMappingTable.tsx
@@ -7,6 +7,7 @@ import {
   useProductTableSetting,
 } from '@/hook/useSettings'
 import { Icon, Spinner } from 'copilot-design-system'
+import { useRef } from 'react'
 
 const MapItemComponent = ({
   mappingItems,
@@ -64,9 +65,18 @@ export default function ProductMappingTable({
     console.error({ error })
   }
 
-  const dropdownRef = useClickOutside<HTMLDivElement>(() => {
-    setOpenDropdowns({})
-  })
+  const dropdownRef = useRef<HTMLDivElement>(null) // single ref for all dropdowns. Only opening one dropdown at a time.
+  const buttonRefs = useRef<Record<number, HTMLButtonElement | null>>({})
+  const setButtonRef = (index: number) => (el: HTMLButtonElement | null) => {
+    // separate button ref as per index.
+    buttonRefs.current[index] = el
+  }
+
+  useClickOutside(
+    dropdownRef,
+    () => setOpenDropdowns({}),
+    Object.values(buttonRefs.current).map((el) => ({ current: el })), // Exclude the button from outside click detection
+  )
 
   return (
     <>
@@ -133,6 +143,7 @@ export default function ProductMappingTable({
                   {/* QuickBooks Items Column */}
                   <td className="border-l border-gray-200 bg-gray-100 hover:bg-gray-150 relative">
                     <button
+                      ref={setButtonRef(index)}
                       onClick={() => toggleDropdown(index)}
                       className="w-full h-full grid grid-cols-6 md:grid-cols-14 transition-colors py-2 pl-4 pr-3"
                     >

--- a/src/hook/useClickOutside.ts
+++ b/src/hook/useClickOutside.ts
@@ -1,14 +1,26 @@
-import { useEffect, useRef, RefObject } from 'react'
+import { useEffect } from 'react'
 
-export default function useClickOutside<T extends HTMLElement>(
-  callback: () => void,
-): RefObject<T | null> {
-  const ref = useRef<T>(null)
-
+export default function useClickOutside(
+  ref: React.RefObject<HTMLElement | null>,
+  handler: () => void,
+  excludeRefs: React.RefObject<HTMLElement | null>[] = [],
+) {
   useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (ref.current && !ref.current.contains(event.target as Node)) {
-        callback()
+    function handleClickOutside(event: MouseEvent) {
+      event.stopPropagation()
+      const target = event.target as Node
+
+      // Check if click is outside the main ref
+      if (ref.current && !ref.current.contains(target)) {
+        // Check if click is on any excluded elements
+        const isExcluded = excludeRefs.some((excludeRef) => {
+          return excludeRef.current && excludeRef.current.contains(target)
+        })
+
+        // Only call handler if not clicking on excluded elements
+        if (!isExcluded) {
+          handler()
+        }
       }
     }
 
@@ -16,7 +28,5 @@ export default function useClickOutside<T extends HTMLElement>(
     return () => {
       document.removeEventListener('mousedown', handleClickOutside)
     }
-  }, [callback])
-
-  return ref
+  }, [ref, handler, excludeRefs])
 }

--- a/src/hook/useSettings.ts
+++ b/src/hook/useSettings.ts
@@ -164,26 +164,12 @@ export const useProductMappingSettings = () => {
 
   const toggleDropdown = (index: number) => {
     setOpenDropdowns((prev) => {
-      // If this dropdown is already open, just close it
-      if (prev[index]) {
-        return {
-          ...prev,
-          [index]: false,
-        }
-      }
-
-      // Otherwise, close all dropdowns and open only this one
-      const newState = prev
-      Object.keys(prev).forEach((key: string) => {
-        newState[parseInt(key)] = false
-      })
-
       return {
-        ...newState,
-        [index]: true,
+        [index]: !prev[index],
       }
     })
   }
+
   const handleSearch = (index: number, value: string) => {
     setSearchTerms((prev) => ({
       ...prev,


### PR DESCRIPTION
## Changes

- [X] update useClickOutside hook to take exlcude refs that exclude the close action on clicked. Those exclude ref would be of table cells.
- [X] click on any other area except for dropdow and active open cell closes the dropdown

## Testing Criteria

[Loom](https://www.loom.com/share/738d84148ac44a44841bd453580701d4?sid=6e70d1f1-3f17-4773-b842-df9ae414b8f1)