### PR TITLE
OUT-2121: implement word break

### DIFF
--- a/src/components/dashboard/settings/sections/product/ProductMappingTable.tsx
+++ b/src/components/dashboard/settings/sections/product/ProductMappingTable.tsx
@@ -104,7 +104,7 @@ export default function ProductMappingTable({
                 <tr key={index} className="transition-colors">
                   {/* Copilot Products Column */}
                   <td className="py-2 pl-4 pr-3">
-                    <div className="text-sm leading-5 text-gray-600">
+                    <div className="text-sm leading-5 text-gray-600 break-all lg:break-normal">
                       {product.name}
                     </div>
                     <div className="text-body-xs leading-5 text-gray-500">


### PR DESCRIPTION
## Changes

- [X] word break implementation for product name in table for smaller screen

## Testing Criteria

<img width="286" height="81" alt="image" src="https://github.com/user-attachments/assets/dcd93cb9-5981-4ee0-8463-286f4378aa2e" />


