### PR TITLE
OUT-2127: open "invoice details" section when enable app button is disabled

### DIFF
--- a/src/hook/useSettings.ts
+++ b/src/hook/useSettings.ts
@@ -539,7 +539,10 @@ export const useInvoiceDetailSettings = () => {
 }
 
 export const useSettings = () => {
-  const [openItems, setOpenItems] = useState<string[]>(['product-mapping'])
+  const { isEnabled } = useApp()
+  const [openItems, setOpenItems] = useState<string[]>(
+    isEnabled ? ['product-mapping'] : ['product-mapping', 'invoice-detail'],
+  )
 
   return { openItems, setOpenItems }
 }


### PR DESCRIPTION
## Changes

- [X] condition to open both accordions (product and invoice) when the app is not enabled

## Testing Criteria

[Loom](https://www.loom.com/share/f7b2614ef3484149b602b3f357a626b8?sid=3ded7102-cdc6-4f17-9e48-b393ac045bb3)