### PR TITLE
OUT-2125: add icon to app bridge

### DIFF
--- a/src/bridge/header.ts
+++ b/src/bridge/header.ts
@@ -9,7 +9,7 @@ export type Icons =
   | 'Templates'
   | 'Trash'
   | 'Download'
-  | 'Disconnected'
+  | 'Disconnect'
 
 interface BreadcrumbsPayload {
   items: {

--- a/src/hook/useDropdown.ts
+++ b/src/hook/useDropdown.ts
@@ -18,11 +18,9 @@ export function useDropdownPosition(
             dropdown.style.top = 'auto'
             dropdown.style.bottom = '100%' // position it above
             dropdown.style.marginTop = '0'
-            dropdown.style.marginBottom = '4px'
           } else {
             dropdown.style.top = '100%' // position it below
             dropdown.style.bottom = 'auto'
-            dropdown.style.marginTop = '4px'
             dropdown.style.marginBottom = '0'
           }
           // Optionally check horizontal overflow too

--- a/src/hook/useQuickbooks.ts
+++ b/src/hook/useQuickbooks.ts
@@ -302,7 +302,7 @@ export const useAppBridge = ({
     actions = [
       {
         label: 'Download sync history',
-        // icon: 'Download',
+        icon: 'Download',
         onClick: downloadCsvAction,
       },
     ]
@@ -310,7 +310,7 @@ export const useAppBridge = ({
     if (isEnabled && syncFlag) {
       actions.push({
         label: 'Disconnect account',
-        // icon: 'Disconnected',
+        icon: 'Disconnect',
         onClick: disconnectAction,
       })
     }


### PR DESCRIPTION
## Changes

- [X] added icon back to app bridge. Icon name typo was causing the menu item to disappear. 

## Testing Criteria

<img width="411" height="234" alt="image" src="https://github.com/user-attachments/assets/3b8785fd-0758-4d97-8761-15f5cd008b1e" />
