### PR TITLE
OUT-2128: allow access when companyId has "default" value

### DIFF
--- a/src/app/api/core/utils/authenticate.ts
+++ b/src/app/api/core/utils/authenticate.ts
@@ -16,7 +16,10 @@ export const _authenticateWithToken = async (token: string): Promise<User> => {
   }
 
   // Access to IU only. The reason for not checking the IUID directly is for the webhook events to pass
-  if (payload.data.clientId || payload.data.companyId) {
+  if (
+    payload.data.clientId ||
+    (payload.data.companyId && payload.data.companyId != 'default') // allow case when the parsed token have companyId = "default"
+  ) {
     throw new APIError(
       httpStatus.UNAUTHORIZED,
       'You do not have access to this resource',


### PR DESCRIPTION
## Changes

- [X] no access if parsed token has clientId or companyId with value other than 'default'

## Testing Criteria

The 401 unauthorized issue can be seen when token has companyId with value "default". Like in this case:

<img width="2085" height="76" alt="image" src="https://github.com/user-attachments/assets/648e4ee2-3613-4673-b7a7-785a28d0d634" />

Implemented condition to by-pass this case.

