### PR TITLE
OUT-2199: Clean up test failed records from sync table and refactor

### DIFF
--- a/src/app/api/core/models/User.model.ts
+++ b/src/app/api/core/models/User.model.ts
@@ -1,10 +1,9 @@
 import { UserRole } from '@/app/api/core/types/user'
 import { Token } from '@/type/common'
 
-type QBConnectionProperties = {
-  accessToken: string
-  serviceItemRef?: string
-  clientFeeRef?: string
+export type QBConnectionProperties = {
+  serviceItemRef: string | null
+  clientFeeRef: string | null
 }
 
 /**

--- a/src/app/api/quickbooks/auth/auth.service.ts
+++ b/src/app/api/quickbooks/auth/auth.service.ts
@@ -159,6 +159,8 @@ export class AuthService extends BaseService {
         incomeAccountRef: insertPayload.incomeAccountRef,
         expenseAccountRef: insertPayload.expenseAccountRef,
         assetAccountRef: insertPayload.assetAccountRef,
+        serviceItemRef: existingToken?.serviceItemRef || null,
+        clientFeeRef: existingToken?.clientFeeRef || null,
       })
       // manage acc ref from intuit and store in qbPortalConnections table
       if (!insertPayload.incomeAccountRef) {
@@ -259,6 +261,8 @@ export class AuthService extends BaseService {
       expenseAccountRef,
       assetAccountRef,
       setting,
+      serviceItemRef,
+      clientFeeRef,
     } = portalQBToken
 
     if (!setting)
@@ -276,6 +280,8 @@ export class AuthService extends BaseService {
       incomeAccountRef: '',
       expenseAccountRef: '',
       assetAccountRef: '',
+      serviceItemRef: '',
+      clientFeeRef: '',
     }
 
     // if sync is false but it has been enabled then don't throw error. We have to log in this case
@@ -298,6 +304,8 @@ export class AuthService extends BaseService {
       incomeAccountRef,
       expenseAccountRef,
       assetAccountRef,
+      serviceItemRef,
+      clientFeeRef,
     }
 
     // Refresh token if expired

--- a/src/app/api/quickbooks/auth/auth.service.ts
+++ b/src/app/api/quickbooks/auth/auth.service.ts
@@ -200,6 +200,10 @@ export class AuthService extends BaseService {
       after(async () => {
         if (existingToken) {
           console.info('Not initial process. Starting the re-sync process')
+          this.user.qbConnection = {
+            serviceItemRef: existingToken.serviceItemRef,
+            clientFeeRef: existingToken.clientFeeRef,
+          }
           const syncService = new SyncService(this.user)
           await syncService.syncFailedRecords()
         }

--- a/src/app/api/quickbooks/sync/sync.service.ts
+++ b/src/app/api/quickbooks/sync/sync.service.ts
@@ -1,20 +1,14 @@
 import { BaseService } from '@/app/api/core/services/base.service'
-import {
-  CustomSyncLogRecordType,
-  CustomSyncLogType,
-  SyncLogService,
-} from '@/app/api/quickbooks/syncLog/syncLog.service'
+import { SyncLogService } from '@/app/api/quickbooks/syncLog/syncLog.service'
 import { InvoiceService } from '@/app/api/quickbooks/invoice/invoice.service'
 import { AuthService } from '@/app/api/quickbooks/auth/auth.service'
 import IntuitAPI, { IntuitAPITokensType } from '@/utils/intuitAPI'
 import { CopilotAPI } from '@/utils/copilotAPI'
 import { EntityType, EventType } from '@/app/api/core/types/log'
-import postgres from 'postgres'
 import User from '@/app/api/core/models/User.model'
 import { PaymentService } from '@/app/api/quickbooks/payment/payment.service'
 import dayjs from 'dayjs'
 import { ProductService } from '@/app/api/quickbooks/product/product.service'
-import { bottleneck } from '@/utils/bottleneck'
 import CustomLogger from '@/utils/logger'
 import { QBSyncLogSelectSchemaType } from '@/db/schema/qbSyncLogs'
 import { z } from 'zod'

--- a/src/app/api/quickbooks/syncLog/syncLog.service.ts
+++ b/src/app/api/quickbooks/syncLog/syncLog.service.ts
@@ -11,9 +11,8 @@ import {
 } from '@/db/schema/qbSyncLogs'
 import { WhereClause } from '@/type/common'
 import dayjs from 'dayjs'
-import { and, eq, sql } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import { json2csv } from 'json-2-csv'
-import postgres from 'postgres'
 
 export type CustomSyncLogRecordType = {
   copilotId: string

--- a/src/app/api/quickbooks/syncLog/syncLog.service.ts
+++ b/src/app/api/quickbooks/syncLog/syncLog.service.ts
@@ -110,6 +110,17 @@ export class SyncLogService extends BaseService {
     }
   }
 
+  async deleteQBSyncLog(id: string): Promise<void> {
+    await this.db
+      .delete(QBSyncLog)
+      .where(
+        and(
+          eq(QBSyncLog.portalId, this.user.workspaceId),
+          eq(QBSyncLog.id, id),
+        ),
+      )
+  }
+
   /**
    * Get all failed sync logs
    */

--- a/src/app/api/quickbooks/webhook/webhook.controller.ts
+++ b/src/app/api/quickbooks/webhook/webhook.controller.ts
@@ -10,7 +10,10 @@ export async function captureWebhookEvent(req: NextRequest) {
   const payload = await req.json()
 
   const qbTokenInfo = await authService.getQBPortalConnection(user.workspaceId)
-  user.qbConnection = qbTokenInfo
+  user.qbConnection = {
+    serviceItemRef: qbTokenInfo.serviceItemRef,
+    clientFeeRef: qbTokenInfo.clientFeeRef,
+  }
   const webhookService = new WebhookService(user)
   await webhookService.handleWebhookEvent(payload, qbTokenInfo)
 

--- a/src/utils/intuitAPI.ts
+++ b/src/utils/intuitAPI.ts
@@ -27,6 +27,8 @@ export type IntuitAPITokensType = Pick<
   | 'incomeAccountRef'
   | 'expenseAccountRef'
   | 'assetAccountRef'
+  | 'serviceItemRef'
+  | 'clientFeeRef'
 >
 
 export const IntuitAPIErrorMessage = '#IntuitAPIErrorMessage#'


### PR DESCRIPTION
## Changes

- [X] refactor to run re-sync failed record cron job in synchronous manner
- [X] bug fix related to service item reference. Service item reference was not fetched properly from DB. Due to this, service item was fetching in QB every time invoice is created.
- [X] product sync log issue fix. was overriding created product log by updated product log.

## Testing Criteria

[Loom](https://www.loom.com/share/4a9d59e52287405c893b61a43687bece?sid=250a81b5-caad-466f-94f6-5ae87ffb28ff)
