### PR TITLE
fix(OUT-3575): handle Intuit OAuth's new error format for auth errors

### DIFF
--- a/src/app/api/core/exceptions/custom.ts
+++ b/src/app/api/core/exceptions/custom.ts
@@ -14,3 +14,22 @@ export function isAxiosError(
     'status' in (error as any).response
   )
 }
+
+/**
+ * Intuit-Oauth has its own error format response.
+ * Format: { error: string, error_description: string, intuit_tid: string }
+ */
+export function isIntuitOAuthError(
+  error: unknown,
+): error is { error: string; error_description: string; intuit_tid: string } {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'error' in error &&
+    typeof (error as any).error === 'string' &&
+    'error_description' in error &&
+    typeof (error as any).error_description === 'string' &&
+    'intuit_tid' in error &&
+    typeof (error as any).intuit_tid === 'string'
+  )
+}

--- a/src/app/api/core/exceptions/custom.ts
+++ b/src/app/api/core/exceptions/custom.ts
@@ -18,18 +18,47 @@ export function isAxiosError(
 /**
  * Intuit-Oauth has its own error format response.
  * Format: { error: string, error_description: string, intuit_tid: string }
+ *
+ * Wrapping in an Error subclass so pRetry doesn't discard the original fields.
  */
-export function isIntuitOAuthError(
-  error: unknown,
-): error is { error: string; error_description: string; intuit_tid: string } {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'error' in error &&
-    typeof (error as any).error === 'string' &&
-    'error_description' in error &&
-    typeof (error as any).error_description === 'string' &&
-    'intuit_tid' in error &&
-    typeof (error as any).intuit_tid === 'string'
-  )
+export class IntuitOAuthError extends Error {
+  error: string
+  error_description: string
+  intuit_tid: string
+
+  constructor(raw: {
+    error: string
+    error_description: string
+    intuit_tid: string
+  }) {
+    super(raw.error_description)
+    this.name = 'IntuitOAuthError'
+    this.error = raw.error
+    this.error_description = raw.error_description
+    this.intuit_tid = raw.intuit_tid
+  }
+
+  static fromRaw(error: unknown): IntuitOAuthError | null {
+    const err = error as Record<string, unknown>
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      typeof err.intuit_tid === 'string' &&
+      typeof err.error === 'string' &&
+      typeof err.error_description === 'string'
+    ) {
+      return new IntuitOAuthError(
+        err as {
+          error: string
+          error_description: string
+          intuit_tid: string
+        },
+      )
+    }
+    return null
+  }
+}
+
+export function isIntuitOAuthError(error: unknown): error is IntuitOAuthError {
+  return error instanceof IntuitOAuthError
 }

--- a/src/app/api/core/utils/withErrorHandler.ts
+++ b/src/app/api/core/utils/withErrorHandler.ts
@@ -70,11 +70,11 @@ export const withErrorHandler = (handler: RequestHandler): RequestHandler => {
       } else if (error instanceof RetryableError) {
         status = error.status
         message = error.message || message
-      } else if (error instanceof Error && error.message) {
-        message = error.message
       } else if (isIntuitOAuthError(error)) {
         message = error.error
         status = httpStatus.BAD_REQUEST
+      } else if (error instanceof Error && error.message) {
+        message = error.message
       } else if (isAxiosError(error)) {
         message = error.response.data.error
         status = error.response.status

--- a/src/app/api/core/utils/withErrorHandler.ts
+++ b/src/app/api/core/utils/withErrorHandler.ts
@@ -7,7 +7,10 @@ import APIError from '@/app/api/core/exceptions/api'
 import httpStatus from 'http-status'
 import { NextRequest, NextResponse } from 'next/server'
 import { ZodError, ZodFormattedError } from 'zod'
-import { isAxiosError } from '@/app/api/core/exceptions/custom'
+import {
+  isAxiosError,
+  isIntuitOAuthError,
+} from '@/app/api/core/exceptions/custom'
 import * as Sentry from '@sentry/nextjs'
 import { RetryableError } from '@/utils/error'
 
@@ -69,6 +72,9 @@ export const withErrorHandler = (handler: RequestHandler): RequestHandler => {
         message = error.message || message
       } else if (error instanceof Error && error.message) {
         message = error.message
+      } else if (isIntuitOAuthError(error)) {
+        message = error.error
+        status = httpStatus.BAD_REQUEST
       } else if (isAxiosError(error)) {
         message = error.response.data.error
         status = error.response.status
@@ -78,7 +84,8 @@ export const withErrorHandler = (handler: RequestHandler): RequestHandler => {
       if (
         error instanceof APIError ||
         error instanceof CopilotApiError ||
-        isAxiosError(error)
+        isAxiosError(error) ||
+        isIntuitOAuthError(error)
       ) {
         Sentry.captureException(error)
       }

--- a/src/app/api/quickbooks/auth/auth.service.ts
+++ b/src/app/api/quickbooks/auth/auth.service.ts
@@ -1,5 +1,5 @@
 import APIError from '@/app/api/core/exceptions/api'
-import { isAxiosError } from '@/app/api/core/exceptions/custom'
+import { isIntuitOAuthError } from '@/app/api/core/exceptions/custom'
 import { BaseService } from '@/app/api/core/services/base.service'
 import { AuthStatus } from '@/app/api/core/types/auth'
 import { NotificationActions } from '@/app/api/core/types/notification'
@@ -9,6 +9,7 @@ import { SettingService } from '@/app/api/quickbooks/setting/setting.service'
 import { SyncService } from '@/app/api/quickbooks/sync/sync.service'
 import { TokenService } from '@/app/api/quickbooks/token/token.service'
 import { intuitRedirectUri } from '@/config'
+import { OAuthErrorCodes } from '@/constant/intuitErrorCode'
 import { AccountTypeObj } from '@/constant/qbConnection'
 import { ConnectionStatus } from '@/db/schema/qbConnectionLogs'
 import {
@@ -328,14 +329,16 @@ export class AuthService extends BaseService {
           )
         }
       } catch (error: unknown) {
-        if (isAxiosError(error)) {
+        console.error('AuthService#handleConnectionError | Error =', error)
+
+        if (isIntuitOAuthError(error)) {
           // Special handling for refresh token expired
           console.error(
             `Refresh token is invalid or expired, reauthorization needed for portalId: ${portalId}.`,
-            { message: error.response.data?.error },
+            { message: error.error_description },
           )
 
-          if (error.response.data?.error === 'invalid_grant') {
+          if (error.error === OAuthErrorCodes.INVALID_GRANT) {
             // indicates that the refresh token is invalid
             // turn off the sync and send notifications to IU (product and email)
             await tokenService.turnOffSync(intuitRealmId)

--- a/src/app/api/quickbooks/auth/auth.service.ts
+++ b/src/app/api/quickbooks/auth/auth.service.ts
@@ -329,7 +329,7 @@ export class AuthService extends BaseService {
           )
         }
       } catch (error: unknown) {
-        console.error('AuthService#handleConnectionError | Error =', error)
+        console.error('AuthService#getQBPortalConnection | Error =', error)
 
         if (isIntuitOAuthError(error)) {
           // Special handling for refresh token expired

--- a/src/constant/intuitErrorCode.ts
+++ b/src/constant/intuitErrorCode.ts
@@ -6,4 +6,4 @@ export const AccountErrorCodes = [
 
 export const OAuthErrorCodes = {
   INVALID_GRANT: 'invalid_grant',
-}
+} as const

--- a/src/constant/intuitErrorCode.ts
+++ b/src/constant/intuitErrorCode.ts
@@ -3,3 +3,7 @@ export const AccountErrorCodes = [
   6190, // account suspended
   6000, // business validation error
 ]
+
+export const OAuthErrorCodes = {
+  INVALID_GRANT: 'invalid_grant',
+}

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -38,14 +38,14 @@ export const getMessageAndCodeFromError = (
       errorMessage = (error.errors?.[0] as IntuitErrorType).Detail
     }
     return { message: errorMessage, code: error.status }
-  } else if (error instanceof Error && error.message) {
-    return { message: error.message, code }
   } else if (isIntuitOAuthError(error)) {
     const message =
       error.error === OAuthErrorCodes.INVALID_GRANT
         ? refreshTokenExpireMessage
         : error.error
     return { message, code: httpStatus.BAD_REQUEST }
+  } else if (error instanceof Error && error.message) {
+    return { message: error.message, code }
   } else if (isAxiosError(error)) {
     return { message: error.response.data.error, code: error.response.status }
   }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,6 +1,11 @@
 import APIError from '@/app/api/core/exceptions/api'
-import { isAxiosError } from '@/app/api/core/exceptions/custom'
+import {
+  isAxiosError,
+  isIntuitOAuthError,
+} from '@/app/api/core/exceptions/custom'
+import { OAuthErrorCodes } from '@/constant/intuitErrorCode'
 import { CopilotApiError, MessagableError } from '@/type/CopilotApiError'
+import { refreshTokenExpireMessage } from '@/utils/auth'
 import { IntuitAPIErrorMessage } from '@/utils/intuitAPI'
 import httpStatus from 'http-status'
 
@@ -35,6 +40,12 @@ export const getMessageAndCodeFromError = (
     return { message: errorMessage, code: error.status }
   } else if (error instanceof Error && error.message) {
     return { message: error.message, code }
+  } else if (isIntuitOAuthError(error)) {
+    const message =
+      error.error === OAuthErrorCodes.INVALID_GRANT
+        ? refreshTokenExpireMessage
+        : error.error
+    return { message, code: httpStatus.BAD_REQUEST }
   } else if (isAxiosError(error)) {
     return { message: error.response.data.error, code: error.response.status }
   }

--- a/src/utils/intuit.ts
+++ b/src/utils/intuit.ts
@@ -1,3 +1,4 @@
+import { IntuitOAuthError } from '@/app/api/core/exceptions/custom'
 import { withRetry } from '@/app/api/core/utils/withRetry'
 import {
   intuitClientId,
@@ -53,7 +54,11 @@ export default class Intuit {
   }
 
   async _refreshAccessToken(refreshToken: string) {
-    return await this.intuitQB.refreshUsingToken(refreshToken)
+    try {
+      return await this.intuitQB.refreshUsingToken(refreshToken)
+    } catch (error: unknown) {
+      throw IntuitOAuthError.fromRaw(error) ?? error
+    }
   }
 
   async getRefreshedQBToken(

--- a/src/utils/intuit.ts
+++ b/src/utils/intuit.ts
@@ -41,16 +41,24 @@ export default class Intuit {
   }
 
   async _authorizeUri(state: { token: string; originUrl?: string }) {
-    // AuthorizationUri
-    const authUri = await this.intuitQB.authorizeUri({
-      scope: [OAuthClient.scopes.Accounting, OAuthClient.scopes.OpenId],
-      state: JSON.stringify(state),
-    })
-    return authUri
+    try {
+      // AuthorizationUri
+      const authUri = await this.intuitQB.authorizeUri({
+        scope: [OAuthClient.scopes.Accounting, OAuthClient.scopes.OpenId],
+        state: JSON.stringify(state),
+      })
+      return authUri
+    } catch (error) {
+      throw IntuitOAuthError.fromRaw(error) ?? error
+    }
   }
 
   async _createToken(url: string) {
-    return await this.intuitQB.createToken(url)
+    try {
+      return await this.intuitQB.createToken(url)
+    } catch (error) {
+      throw IntuitOAuthError.fromRaw(error) ?? error
+    }
   }
 
   async _refreshAccessToken(refreshToken: string) {


### PR DESCRIPTION
## Summary
- Intuit silently changed their OAuth error response from Axios-style `{ response: { status, data } }` to `{ error, error_description, intuit_tid }`. This caused refresh token expiry errors to go undetected, preventing notification emails to IUs.
- Added `IntuitOAuthError extends Error` class with a `fromRaw()` factory method to wrap Intuit's plain-object errors into proper Error instances. This is necessary because `pRetry` discards non-Error throws.
- Added `isIntuitOAuthError` type guard (now `instanceof` based) and updated all error handling paths.
- Extracted `OAuthErrorCodes.INVALID_GRANT` constant to replace magic string comparisons.

## Changes
| File | Change |
|---|---|
| `src/app/api/core/exceptions/custom.ts` | `IntuitOAuthError` class with `fromRaw()` factory + `isIntuitOAuthError` instanceof guard |
| `src/app/api/core/utils/withErrorHandler.ts` | Handle `IntuitOAuthError` before generic `Error` branch + Sentry capture |
| `src/app/api/quickbooks/auth/auth.service.ts` | Switch from `isAxiosError` to `isIntuitOAuthError`, use constant for `invalid_grant` check |
| `src/constant/intuitErrorCode.ts` | Added `OAuthErrorCodes` with `as const` |
| `src/utils/error.ts` | Handle `IntuitOAuthError` before generic `Error` in `getMessageAndCodeFromError` |
| `src/utils/intuit.ts` | Wrap plain Intuit OAuth errors via `IntuitOAuthError.fromRaw()` in all SDK calls (`_refreshAccessToken`, `_authorizeUri`, `_createToken`) |

## Key design decisions
- **Why `IntuitOAuthError extends Error`?** — `pRetry` discards non-Error throws with a generic `TypeError`, losing all Intuit error fields. Wrapping in a proper Error subclass preserves them through the retry pipeline.
- **Why `fromRaw()` factory?** — Keeps plain-object shape detection in one place. Callers just do `throw IntuitOAuthError.fromRaw(error) ?? error`.
- **Why reorder `isIntuitOAuthError` before `instanceof Error`?** — Since `IntuitOAuthError extends Error`, the generic `instanceof Error` branch would catch it first, making our specific handler dead code.
- **No retry for OAuth errors** — `shouldRetry` in `withRetry.ts` only retries `status === 429`. `IntuitOAuthError` has no status, so it fails fast. Network/rate-limit errors still retry normally.

## Test plan
- [ ] Simulate expired refresh token — verify `turnOffSync` is called and IU notification email is sent
- [ ] Simulate non-`invalid_grant` OAuth error (e.g. `invalid_client`) — verify error is caught and reported to Sentry
- [ ] Verify existing Axios-style errors from QuickBooks Data Services API are still handled correctly
- [ ] Verify network errors during token refresh are still retried (up to 3 times)

🤖 Generated with [Claude Code](https://claude.com/claude-code)