### PR TITLE
OUT-3578: add afterIfAvailable utility for non-request contexts

### DIFF
--- a/src/app/api/core/utils/afterIfAvailable.ts
+++ b/src/app/api/core/utils/afterIfAvailable.ts
@@ -1,0 +1,21 @@
+import { after } from 'next/server'
+
+/**
+ * Runs the callback via Next.js `after()` if inside a request scope,
+ * otherwise executes it directly. This allows shared service code to
+ * work in both Vercel serverless (request context) and Trigger.dev /
+ * CLI (no request context) environments.
+ *
+ * `after()` is a pure registration call — the only errors it can throw
+ * are scope/context errors. Real callback errors are handled separately
+ * via `.catch()` in the fallback path.
+ */
+export function afterIfAvailable(callback: () => Promise<void>): void {
+  try {
+    after(callback)
+  } catch {
+    void callback().catch((err) => {
+      console.error('[afterIfAvailable] callback failed:', err)
+    })
+  }
+}

--- a/src/app/api/quickbooks/auth/auth.service.ts
+++ b/src/app/api/quickbooks/auth/auth.service.ts
@@ -31,6 +31,7 @@ import IntuitAPI, { IntuitAPITokensType } from '@/utils/intuitAPI'
 import dayjs from 'dayjs'
 import { and, eq, SQL } from 'drizzle-orm'
 import httpStatus from 'http-status'
+import { afterIfAvailable } from '@/app/api/core/utils/afterIfAvailable'
 import { after } from 'next/server'
 
 export class AuthService extends BaseService {
@@ -344,7 +345,11 @@ export class AuthService extends BaseService {
             await tokenService.turnOffSync(intuitRealmId)
 
             // send notification to IU
-            after(async () => {
+            afterIfAvailable(async () => {
+              console.info(
+                'AuthService#handleConnectionError | running after() .. | Sending notification to IU',
+              )
+
               const notificationService = new NotificationService(this.user)
               await notificationService.sendNotificationToIU(
                 intiatedBy,


### PR DESCRIPTION
## Summary
- Next.js `after()` throws when called outside a request scope (Trigger.dev background jobs, CLI scripts).
- Added `afterIfAvailable()` utility that tries `after()` and falls back to direct async execution when no request context is available.
- Applied to `getQBPortalConnection()`'s notification path in `auth.service.ts`, which runs in both Vercel serverless and Trigger.dev contexts.

## Changes
| File | Change |
|---|---|
| `src/app/api/core/utils/afterIfAvailable.ts` | New utility — tries `after()`, catches scope errors, falls back to direct execution with `.catch()` error logging |
| `src/app/api/quickbooks/auth/auth.service.ts` | Use `afterIfAvailable` for IU notification in `getQBPortalConnection`; `handleTokenExchange` keeps `after()` (request-only) |

## Test plan
- Trigger a refresh token expiry via Trigger.dev `resyncFailedRecords` task — verify notification fires without `after()` scope error
- Trigger a refresh token expiry via Vercel serverless route — verify `after()` still defers the callback as before
- Simulate notification failure in fallback path — verify error is logged via `[afterIfAvailable] callback failed:`

🤖 Generated with [Claude Code](https://claude.com/claude-code)