### PR TITLE
feat(OUT-3604): QBO bank deposits for automatic bank reconciliation

### DIFF
--- a/src/app/api/core/types/log.ts
+++ b/src/app/api/core/types/log.ts
@@ -19,6 +19,7 @@ export enum EventType {
   SUCCEEDED = 'succeeded',
   MAPPED = 'mapped',
   UNMAPPED = 'unmapped',
+  DEPOSITED = 'deposited',
 }
 
 /**

--- a/src/app/api/quickbooks/auth/auth.service.ts
+++ b/src/app/api/quickbooks/auth/auth.service.ts
@@ -145,6 +145,9 @@ export class AuthService extends BaseService {
         assetAccountRef: insertPayload.assetAccountRef,
         serviceItemRef: existingToken?.serviceItemRef || null,
         clientFeeRef: existingToken?.clientFeeRef || null,
+        undepositedFundsAccountRef:
+          existingToken?.undepositedFundsAccountRef || null,
+        bankAccountRef: existingToken?.bankAccountRef || null,
       })
       // handle accounts
       const createPayload = await this.handleAccountReferences(
@@ -244,6 +247,8 @@ export class AuthService extends BaseService {
       setting,
       serviceItemRef,
       clientFeeRef,
+      undepositedFundsAccountRef,
+      bankAccountRef,
       isSuspended,
     } = portalQBToken
 
@@ -266,6 +271,8 @@ export class AuthService extends BaseService {
       assetAccountRef: '',
       serviceItemRef: '',
       clientFeeRef: '',
+      undepositedFundsAccountRef: null,
+      bankAccountRef: null,
     }
 
     // if sync is false but it has been enabled then don't throw error. We have to log in this case
@@ -287,6 +294,8 @@ export class AuthService extends BaseService {
       assetAccountRef,
       serviceItemRef,
       clientFeeRef,
+      undepositedFundsAccountRef,
+      bankAccountRef,
     }
 
     // Refresh token if expired

--- a/src/app/api/quickbooks/invoice/invoice.service.ts
+++ b/src/app/api/quickbooks/invoice/invoice.service.ts
@@ -870,11 +870,37 @@ export class InvoiceService extends BaseService {
     }
 
     const invoiceAmount = Number(z.string().parse(invoiceLog.amount)) / 100
+
+    // Check if bank deposit fee flow is enabled — if so, route payment through Undeposited Funds
+    const settingService = new SettingService(this.user)
+    const setting = await settingService.getOneByPortalId([
+      'absorbedFeeFlag',
+      'bankDepositFeeFlag',
+    ])
+    const useBankDepositFlow =
+      setting?.absorbedFeeFlag && setting?.bankDepositFeeFlag
+
+    let depositToAccountRef: { value: string } | undefined
+    if (useBankDepositFlow) {
+      const tokenService = new TokenService(this.user)
+      const undepositedFundsRef =
+        await tokenService.checkAndUpdateAccountStatus(
+          AccountTypeObj.UndepositedFunds,
+          qbTokenInfo.intuitRealmId,
+          new IntuitAPI(qbTokenInfo),
+          qbTokenInfo.undepositedFundsAccountRef ?? undefined,
+        )
+      depositToAccountRef = { value: undepositedFundsRef }
+    }
+
     const qbPaymentPayload = {
       TotalAmt: invoiceAmount,
       CustomerRef: {
         value: existingCustomer.qbCustomerId,
       },
+      ...(depositToAccountRef && {
+        DepositToAccountRef: depositToAccountRef,
+      }),
       Line: [
         {
           Amount: invoiceAmount,

--- a/src/app/api/quickbooks/payment/payment.service.ts
+++ b/src/app/api/quickbooks/payment/payment.service.ts
@@ -25,6 +25,8 @@ import {
   QBPaymentCreatePayloadType,
   QBPurchaseCreatePayloadSchema,
   QBPurchaseCreatePayloadType,
+  QBDepositCreatePayloadSchema,
+  QBDepositCreatePayloadType,
 } from '@/type/dto/intuitAPI.dto'
 import { PaymentSucceededResponseType } from '@/type/dto/webhook.dto'
 import { getMessageAndCodeFromError } from '@/utils/error'
@@ -182,6 +184,75 @@ export class PaymentService extends BaseService {
         Id: res.Purchase?.Id,
       }
       await intuitApi.deletePurchase(deletePayload)
+      throw error
+    }
+  }
+
+  async createBankDepositForPayment(
+    intuitApi: IntuitAPI,
+    opts: {
+      qbPaymentId: string
+      grossAmount: number
+      feeAmount: number
+      bankAccountRef: string
+      expenseAccountRef: string
+      txnDate: string
+      invoiceNumber: string
+      paymentId: string
+    },
+  ): Promise<void> {
+    const netAmount = opts.grossAmount - opts.feeAmount
+
+    const depositPayload: QBDepositCreatePayloadType = {
+      DepositToAccountRef: { value: opts.bankAccountRef },
+      TxnDate: opts.txnDate,
+      Line: [
+        {
+          Amount: opts.grossAmount,
+          LinkedTxn: [
+            { TxnId: opts.qbPaymentId, TxnType: 'Payment' as const },
+          ],
+        },
+        {
+          Amount: -opts.feeAmount,
+          DetailType: 'DepositLineDetail' as const,
+          DepositLineDetail: {
+            AccountRef: { value: opts.expenseAccountRef },
+          },
+          Description: 'Stripe processing fee',
+        },
+      ],
+    }
+
+    const parsedPayload = QBDepositCreatePayloadSchema.parse(depositPayload)
+
+    console.info(
+      `PaymentService#createBankDepositForPayment | Creating bank deposit: gross=${opts.grossAmount}, fee=${opts.feeAmount}, net=${netAmount}`,
+    )
+
+    const res = await intuitApi.createDeposit(parsedPayload)
+
+    try {
+      await this.logSync(
+        opts.paymentId,
+        {
+          qbInvoiceId: res.Deposit.Id,
+          invoiceNumber: opts.invoiceNumber,
+        },
+        EventType.DEPOSITED,
+        EntityType.PAYMENT,
+        {
+          amount: (opts.grossAmount * 100).toFixed(2),
+          feeAmount: (opts.feeAmount * 100).toFixed(2),
+          remark: 'Bank deposit with fee deduction',
+          qbItemName: 'Assembly Fees',
+          errorMessage: '',
+        },
+      )
+    } catch (error: unknown) {
+      console.error(
+        'PaymentService#createBankDepositForPayment | Failed to log sync, but deposit was created in QBO',
+      )
       throw error
     }
   }

--- a/src/app/api/quickbooks/setting/setting.controller.ts
+++ b/src/app/api/quickbooks/setting/setting.controller.ts
@@ -22,7 +22,11 @@ export async function getSettings(req: NextRequest) {
       'initialProductSettingMap',
     )
     if (parsedType.data === SettingType.INVOICE)
-      returningFields.push('absorbedFeeFlag', 'useCompanyNameFlag')
+      returningFields.push(
+        'absorbedFeeFlag',
+        'bankDepositFeeFlag',
+        'useCompanyNameFlag',
+      )
     if (parsedType.data === SettingType.PRODUCT)
       returningFields.push('createNewProductFlag')
   }

--- a/src/app/api/quickbooks/token/token.service.ts
+++ b/src/app/api/quickbooks/token/token.service.ts
@@ -156,6 +156,9 @@ export class TokenService extends BaseService {
       case AccountTypeObj.Asset:
         payload = { assetAccountRef: accountRef }
         break
+      case AccountTypeObj.UndepositedFunds:
+        payload = { undepositedFundsAccountRef: accountRef }
+        break
       default:
         throw new APIError(
           httpStatus.BAD_REQUEST,
@@ -266,6 +269,29 @@ export class TokenService extends BaseService {
     return assetAccRef.Id
   }
 
+  private async getUndepositedFundsAccountRef(
+    intuitApi: IntuitAPI,
+  ): Promise<string> {
+    // "Undeposited Funds" is a system account in every QBO company.
+    // Look up by subtype first (more reliable than name if user renamed it).
+    const query = `SELECT Id FROM Account WHERE AccountSubType = 'UndepositedFunds' AND Active = true maxresults 1`
+    const result = await intuitApi.customQuery(query)
+    if (result?.Account?.[0]?.Id) {
+      return result.Account[0].Id
+    }
+
+    // Fallback: try by name
+    const byName = await intuitApi.getAnAccount('Undeposited Funds')
+    if (byName?.Id) {
+      return byName.Id
+    }
+
+    throw new APIError(
+      httpStatus.INTERNAL_SERVER_ERROR,
+      'TokenService#getUndepositedFundsAccountRef | Undeposited Funds account not found in QuickBooks',
+    )
+  }
+
   private async restoreAccountRef(
     accountType: AccountType,
     intuitApi: IntuitAPI,
@@ -277,6 +303,8 @@ export class TokenService extends BaseService {
         return this.getOrCreateExpenseAccountRef(intuitApi)
       case AccountTypeObj.Asset:
         return this.getOrCreateAssetAccountRef(intuitApi)
+      case AccountTypeObj.UndepositedFunds:
+        return this.getUndepositedFundsAccountRef(intuitApi)
       default:
         throw new APIError(
           httpStatus.BAD_REQUEST,

--- a/src/app/api/quickbooks/webhook/webhook.service.ts
+++ b/src/app/api/quickbooks/webhook/webhook.service.ts
@@ -19,10 +19,12 @@ import {
   WebhookEventResponseSchema,
   WebhookEventResponseType,
 } from '@/type/dto/webhook.dto'
+import { TokenService } from '@/app/api/quickbooks/token/token.service'
+import { AccountTypeObj } from '@/constant/qbConnection'
 import { validateAccessToken } from '@/utils/auth'
 import { CopilotAPI } from '@/utils/copilotAPI'
 import { ErrorMessageAndCode, getMessageAndCodeFromError } from '@/utils/error'
-import { IntuitAPITokensType } from '@/utils/intuitAPI'
+import IntuitAPI, { IntuitAPITokensType } from '@/utils/intuitAPI'
 import CustomLogger from '@/utils/logger'
 import { sleep } from '@/utils/sleep'
 import {
@@ -402,7 +404,10 @@ export class WebhookService extends BaseService {
     if (feeAmount?.paidByPlatform && feeAmount.paidByPlatform > 0) {
       // check if absorbed fee flag is true
       const settingService = new SettingService(this.user)
-      const setting = await settingService.getOneByPortalId(['absorbedFeeFlag'])
+      const setting = await settingService.getOneByPortalId([
+        'absorbedFeeFlag',
+        'bankDepositFeeFlag',
+      ])
 
       if (!setting?.absorbedFeeFlag) {
         console.info(
@@ -411,10 +416,15 @@ export class WebhookService extends BaseService {
         return
       }
 
+      const useBankDepositFlow = setting.bankDepositFeeFlag
+      const idempotencyEventType = useBankDepositFlow
+        ? EventType.DEPOSITED
+        : EventType.SUCCEEDED
+
       const syncLogService = new SyncLogService(this.user)
       const syncLog = await syncLogService.getOneByCopilotIdAndEventType({
         copilotId: parsedPaymentSucceedResource.data.id,
-        eventType: EventType.SUCCEEDED,
+        eventType: idempotencyEventType,
         entityType: EntityType.PAYMENT,
       })
       if (syncLog?.status === LogStatus.SUCCESS) {
@@ -435,13 +445,24 @@ export class WebhookService extends BaseService {
             `Invoice not found for invoice id: ${parsedPaymentSucceedResource.data.invoiceId}`,
           )
         validateAccessToken(qbTokenInfo)
-        // only track if the fee amount is paid by platform
         const paymentService = new PaymentService(this.user)
-        await paymentService.webhookPaymentSucceeded(
-          parsedPaymentSucceedResource,
-          qbTokenInfo,
-          invoice,
-        )
+
+        if (useBankDepositFlow) {
+          // Bank deposit flow: create a QBO Bank Deposit that matches the net bank amount
+          await this.handleBankDepositFlow(
+            parsedPaymentSucceedResource,
+            qbTokenInfo,
+            invoice,
+            paymentService,
+          )
+        } else {
+          // Legacy flow: create a standalone expense for absorbed fees
+          await paymentService.webhookPaymentSucceeded(
+            parsedPaymentSucceedResource,
+            qbTokenInfo,
+            invoice,
+          )
+        }
       } catch (error: unknown) {
         const errorWithCode = getMessageAndCodeFromError(error)
         const errorMessage = errorWithCode.message
@@ -450,11 +471,13 @@ export class WebhookService extends BaseService {
         await syncLogService.updateOrCreateQBSyncLog({
           portalId: this.user.workspaceId,
           entityType: EntityType.PAYMENT,
-          eventType: EventType.SUCCEEDED,
+          eventType: idempotencyEventType,
           status: LogStatus.FAILED,
           copilotId: parsedPaymentSucceedResource.data.id,
           feeAmount: feeAmount ? feeAmount.paidByPlatform.toFixed(2) : '0',
-          remark: 'Absorbed fees',
+          remark: useBankDepositFlow
+            ? 'Bank deposit with fee deduction'
+            : 'Absorbed fees',
           qbItemName: 'Assembly Fees',
           errorMessage,
           deletedAt: getDeletedAtForAuthAccountCategoryLog(errorWithCode),
@@ -466,5 +489,70 @@ export class WebhookService extends BaseService {
         return
       }
     }
+  }
+
+  /**
+   * Creates a QBO Bank Deposit that moves the payment from Undeposited Funds
+   * to the customer's bank account, deducting Stripe fees.
+   * This makes the deposit amount match the actual bank transaction.
+   */
+  private async handleBankDepositFlow(
+    parsedPaymentSucceedResource: { data: { id: string; invoiceId: string; feeAmount: { paidByPlatform: number; paidByClient: number } | null; createdAt: string } },
+    qbTokenInfo: IntuitAPITokensType,
+    invoice: { number: string },
+    paymentService: PaymentService,
+  ) {
+    const feeAmount = parsedPaymentSucceedResource.data.feeAmount
+    if (!feeAmount)
+      throw new APIError(httpStatus.BAD_REQUEST, 'Fee amount is not found')
+
+    // Look up the QBO Payment ID from the sync log (created by webhookInvoicePaid)
+    const syncLogService = new SyncLogService(this.user)
+    const paidSyncLog = await syncLogService.getOneByCopilotIdAndEventType({
+      copilotId: parsedPaymentSucceedResource.data.invoiceId,
+      eventType: EventType.PAID,
+      entityType: EntityType.INVOICE,
+    })
+
+    if (!paidSyncLog?.quickbooksId) {
+      throw new APIError(
+        httpStatus.NOT_FOUND,
+        `QBO Payment not found in sync log for invoice: ${parsedPaymentSucceedResource.data.invoiceId}. The invoice.paid event may not have been processed yet.`,
+      )
+    }
+
+    const qbPaymentId = paidSyncLog.quickbooksId
+    const grossAmount = Number(paidSyncLog.amount) / 100
+    const platformFee = feeAmount.paidByPlatform / 100
+
+    // Get or verify account refs
+    const intuitApi = new IntuitAPI(qbTokenInfo)
+    const tokenService = new TokenService(this.user)
+
+    const expenseAccountRef = await tokenService.checkAndUpdateAccountStatus(
+      AccountTypeObj.Expense,
+      qbTokenInfo.intuitRealmId,
+      intuitApi,
+      qbTokenInfo.expenseAccountRef,
+    )
+
+    const bankAccountRef = qbTokenInfo.bankAccountRef
+    if (!bankAccountRef) {
+      throw new APIError(
+        httpStatus.BAD_REQUEST,
+        'Bank account ref is not configured. Please select a bank account in the QuickBooks integration settings.',
+      )
+    }
+
+    await paymentService.createBankDepositForPayment(intuitApi, {
+      qbPaymentId,
+      grossAmount,
+      feeAmount: platformFee,
+      bankAccountRef,
+      expenseAccountRef,
+      txnDate: parsedPaymentSucceedResource.data.createdAt.split('T')[0],
+      invoiceNumber: invoice.number,
+      paymentId: parsedPaymentSucceedResource.data.id,
+    })
   }
 }

--- a/src/cmd/renameQbAccount/renameQbAccount.service.ts
+++ b/src/cmd/renameQbAccount/renameQbAccount.service.ts
@@ -58,6 +58,8 @@ export class RenameQbAccountService extends BaseService {
       assetAccountRef: portal.assetAccountRef,
       serviceItemRef: portal.serviceItemRef,
       clientFeeRef: portal.clientFeeRef,
+      undepositedFundsAccountRef: portal.undepositedFundsAccountRef,
+      bankAccountRef: portal.bankAccountRef,
     }
     const intuitApi = new IntuitAPI(qbTokenInfo)
     await this.handleRefreshToken()

--- a/src/components/dashboard/settings/sections/invoice/InvoiceDetail.tsx
+++ b/src/components/dashboard/settings/sections/invoice/InvoiceDetail.tsx
@@ -28,11 +28,31 @@ export default function InvoiceDetail({
             label="Add absorbed fees to an Expense Account in QuickBooks"
             description="Record Assembly processing fees as expenses in the 'Assembly Processing Fees' expense account in QuickBooks."
             checked={settingState.absorbedFeeFlag}
-            onChange={() =>
-              changeSettings('absorbedFeeFlag', !settingState.absorbedFeeFlag)
-            }
+            onChange={() => {
+              const newValue = !settingState.absorbedFeeFlag
+              changeSettings('absorbedFeeFlag', newValue)
+              // Turn off bank deposit flag if absorbed fees is being disabled
+              if (!newValue && settingState.bankDepositFeeFlag) {
+                changeSettings('bankDepositFeeFlag', false)
+              }
+            }}
           />
         </div>
+        {settingState.absorbedFeeFlag && (
+          <div className="mb-5 ml-6">
+            <Checkbox
+              label="Create bank deposits for automatic bank reconciliation"
+              description="When payments are received, create QuickBooks bank deposits that match the net amount deposited to your bank (after Stripe fees), making bank transaction matching automatic."
+              checked={settingState.bankDepositFeeFlag}
+              onChange={() =>
+                changeSettings(
+                  'bankDepositFeeFlag',
+                  !settingState.bankDepositFeeFlag,
+                )
+              }
+            />
+          </div>
+        )}
         <div className="mb-6">
           <Checkbox
             label={`Use ${getWorkspaceLabel(workspace).groupTerm} name when syncing invoices billed to ${getWorkspaceLabel(workspace).groupTermPlural}`}

--- a/src/constant/qbConnection.ts
+++ b/src/constant/qbConnection.ts
@@ -2,4 +2,5 @@ export const AccountTypeObj = {
   Income: 'income',
   Expense: 'expense',
   Asset: 'asset',
+  UndepositedFunds: 'undepositedFunds',
 } as const

--- a/src/db/migrations/20260415184949_add_bank_deposit_fee_columns.sql
+++ b/src/db/migrations/20260415184949_add_bank_deposit_fee_columns.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "qb_portal_connections" ADD COLUMN "undeposited_funds_account_ref" varchar(100);--> statement-breakpoint
+ALTER TABLE "qb_portal_connections" ADD COLUMN "bank_account_ref" varchar(100);--> statement-breakpoint
+ALTER TABLE "qb_settings" ADD COLUMN "bank_deposit_fee_flag" boolean DEFAULT false NOT NULL;

--- a/src/db/migrations/meta/20260415184949_snapshot.json
+++ b/src/db/migrations/meta/20260415184949_snapshot.json
@@ -1,0 +1,1001 @@
+{
+  "id": "2140b645-01c8-4153-b18f-eb1bf7ae6c5d",
+  "prevId": "1f41b71d-f21a-44c6-af6a-4fda7762d670",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.qb_connection_logs": {
+      "name": "qb_connection_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_status": {
+          "name": "connection_status",
+          "type": "connection_statuses",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qb_customers": {
+      "name": "qb_customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_company_id": {
+          "name": "client_company_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "given_name": {
+          "name": "given_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "family_name": {
+          "name": "family_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_type": {
+          "name": "customer_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'client'"
+        },
+        "qb_sync_token": {
+          "name": "qb_sync_token",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qb_customer_id": {
+          "name": "qb_customer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_qb_customers_client_company_id_type_active_idx": {
+          "name": "uq_qb_customers_client_company_id_type_active_idx",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "customer_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"qb_customers\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qb_invoice_sync": {
+      "name": "qb_invoice_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qb_invoice_id": {
+          "name": "qb_invoice_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qb_sync_token": {
+          "name": "qb_sync_token",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_statuses",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "qb_invoice_sync_customer_id_qb_customers_id_fk": {
+          "name": "qb_invoice_sync_customer_id_qb_customers_id_fk",
+          "tableFrom": "qb_invoice_sync",
+          "tableTo": "qb_customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qb_payment_sync": {
+      "name": "qb_payment_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qb_payment_id": {
+          "name": "qb_payment_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qb_sync_token": {
+          "name": "qb_sync_token",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qb_portal_connections": {
+      "name": "qb_portal_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intuit_realm_id": {
+          "name": "intuit_realm_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_in": {
+          "name": "expires_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x_refresh_token_expires_in": {
+          "name": "x_refresh_token_expires_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_set_time": {
+          "name": "token_set_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intiated_by": {
+          "name": "intiated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "income_account_ref": {
+          "name": "income_account_ref",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_account_ref": {
+          "name": "asset_account_ref",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expense_account_ref": {
+          "name": "expense_account_ref",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_fee_ref": {
+          "name": "client_fee_ref",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_item_ref": {
+          "name": "service_item_ref",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "undeposited_funds_account_ref": {
+          "name": "undeposited_funds_account_ref",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bank_account_ref": {
+          "name": "bank_account_ref",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_suspended": {
+          "name": "is_suspended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_qb_portal_connections_portal_id_idx": {
+          "name": "uq_qb_portal_connections_portal_id_idx",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qb_product_sync": {
+      "name": "qb_product_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "copilot_name": {
+          "name": "copilot_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "copilot_unit_price": {
+          "name": "copilot_unit_price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qb_item_id": {
+          "name": "qb_item_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qb_sync_token": {
+          "name": "qb_sync_token",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_excluded": {
+          "name": "is_excluded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qb_settings": {
+      "name": "qb_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "absorbed_fee_flag": {
+          "name": "absorbed_fee_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bank_deposit_fee_flag": {
+          "name": "bank_deposit_fee_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "company_name_flag": {
+          "name": "company_name_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "create_new_product_flag": {
+          "name": "create_new_product_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "initial_invoice_setting_map": {
+          "name": "initial_invoice_setting_map",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "initial_product_setting_map": {
+          "name": "initial_product_setting_map",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sync_flag": {
+          "name": "sync_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "qb_settings_portal_id_qb_portal_connections_portal_id_fk": {
+          "name": "qb_settings_portal_id_qb_portal_connections_portal_id_fk",
+          "tableFrom": "qb_settings",
+          "tableTo": "qb_portal_connections",
+          "columnsFrom": [
+            "portal_id"
+          ],
+          "columnsTo": [
+            "portal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qb_sync_logs": {
+      "name": "qb_sync_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "entity_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invoice'"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "event_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "status": {
+          "name": "status",
+          "type": "log_statuses",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'success'"
+        },
+        "sync_at": {
+          "name": "sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "copilot_id": {
+          "name": "copilot_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quickbooks_id": {
+          "name": "quickbooks_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remark": {
+          "name": "remark",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_email": {
+          "name": "customer_email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_amount": {
+          "name": "fee_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_price": {
+          "name": "product_price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qb_item_name": {
+          "name": "qb_item_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "copilot_price_id": {
+          "name": "copilot_price_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "failed_record_category_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'others'"
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.connection_statuses": {
+      "name": "connection_statuses",
+      "schema": "public",
+      "values": [
+        "pending",
+        "success",
+        "error"
+      ]
+    },
+    "public.invoice_statuses": {
+      "name": "invoice_statuses",
+      "schema": "public",
+      "values": [
+        "draft",
+        "open",
+        "paid",
+        "void",
+        "deleted"
+      ]
+    },
+    "public.entity_types": {
+      "name": "entity_types",
+      "schema": "public",
+      "values": [
+        "invoice",
+        "product",
+        "payment"
+      ]
+    },
+    "public.event_types": {
+      "name": "event_types",
+      "schema": "public",
+      "values": [
+        "created",
+        "updated",
+        "paid",
+        "voided",
+        "deleted",
+        "succeeded",
+        "mapped",
+        "unmapped"
+      ]
+    },
+    "public.failed_record_category_types": {
+      "name": "failed_record_category_types",
+      "schema": "public",
+      "values": [
+        "auth",
+        "account",
+        "others"
+      ]
+    },
+    "public.log_statuses": {
+      "name": "log_statuses",
+      "schema": "public",
+      "values": [
+        "success",
+        "failed",
+        "info"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1775465579546,
       "tag": "20260406085259_add_customer_type_column_in_customers_table",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1776278989518,
+      "tag": "20260415184949_add_bank_deposit_fee_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/qbPortalConnections.ts
+++ b/src/db/schema/qbPortalConnections.ts
@@ -28,6 +28,10 @@ export const QBPortalConnection = table(
       .notNull(),
     clientFeeRef: t.varchar('client_fee_ref', { length: 100 }),
     serviceItemRef: t.varchar('service_item_ref', { length: 100 }),
+    undepositedFundsAccountRef: t.varchar('undeposited_funds_account_ref', {
+      length: 100,
+    }),
+    bankAccountRef: t.varchar('bank_account_ref', { length: 100 }),
     isSuspended: t.boolean('is_suspended').notNull().default(false),
     ...timestamps,
   },

--- a/src/db/schema/qbSettings.ts
+++ b/src/db/schema/qbSettings.ts
@@ -15,6 +15,10 @@ export const QBSetting = table('qb_settings', {
     .references(() => QBPortalConnection.portalId, { onDelete: 'cascade' })
     .notNull(),
   absorbedFeeFlag: t.boolean('absorbed_fee_flag').default(false).notNull(),
+  bankDepositFeeFlag: t
+    .boolean('bank_deposit_fee_flag')
+    .default(false)
+    .notNull(),
   useCompanyNameFlag: t.boolean('company_name_flag').default(false).notNull(),
   createNewProductFlag: t
     .boolean('create_new_product_flag')

--- a/src/db/service/token.service.ts
+++ b/src/db/service/token.service.ts
@@ -73,5 +73,7 @@ export const getPortalTokens = async (
     assetAccountRef: portalConnection.assetAccountRef,
     serviceItemRef: portalConnection.serviceItemRef,
     clientFeeRef: portalConnection.clientFeeRef,
+    undepositedFundsAccountRef: portalConnection.undepositedFundsAccountRef,
+    bankAccountRef: portalConnection.bankAccountRef,
   }
 }

--- a/src/hook/useSettings.ts
+++ b/src/hook/useSettings.ts
@@ -497,6 +497,7 @@ export const useMapItem = (
 export const useInvoiceDetailSettings = () => {
   const initialInvoiceSetting = {
     absorbedFeeFlag: false,
+    bankDepositFeeFlag: false,
     useCompanyNameFlag: false,
   }
   const { token, setAppParams } = useApp()

--- a/src/type/common.ts
+++ b/src/type/common.ts
@@ -276,6 +276,7 @@ export const SettingRequestSchema = z
     id: z.string().optional(),
     type: z.nativeEnum(SettingType),
     absorbedFeeFlag: z.boolean().optional(),
+    bankDepositFeeFlag: z.boolean().optional(),
     useCompanyNameFlag: z.boolean().optional(),
     createNewProductFlag: z.boolean().optional(),
   })
@@ -286,6 +287,13 @@ export const SettingRequestSchema = z
           path: ['absorbedFeeFlag'],
           code: z.ZodIssueCode.custom,
           message: 'absorbedFeeFlag is required when type is invoice',
+        })
+      }
+      if (typeof val.bankDepositFeeFlag !== 'boolean') {
+        ctx.addIssue({
+          path: ['bankDepositFeeFlag'],
+          code: z.ZodIssueCode.custom,
+          message: 'bankDepositFeeFlag is required when type is invoice',
         })
       }
       if (typeof val.useCompanyNameFlag !== 'boolean') {
@@ -310,7 +318,10 @@ export const SettingRequestSchema = z
 export type SettingRequestType = z.infer<typeof SettingRequestSchema>
 
 export type InvoiceSettingType = Required<
-  Pick<SettingRequestType, 'absorbedFeeFlag' | 'useCompanyNameFlag'>
+  Pick<
+    SettingRequestType,
+    'absorbedFeeFlag' | 'bankDepositFeeFlag' | 'useCompanyNameFlag'
+  >
 > & { id?: string }
 
 export type ProductSettingType = Required<

--- a/src/type/dto/intuitAPI.dto.ts
+++ b/src/type/dto/intuitAPI.dto.ts
@@ -113,6 +113,11 @@ export const QBPaymentCreatePayloadSchema = z.object({
   CustomerRef: z.object({
     value: z.string(),
   }),
+  DepositToAccountRef: z
+    .object({
+      value: z.string(),
+    })
+    .optional(),
   Line: z.array(
     z.object({
       Amount: z.number(),
@@ -192,6 +197,38 @@ export const QBPurchaseCreatePayloadSchema = z.object({
 
 export type QBPurchaseCreatePayloadType = z.infer<
   typeof QBPurchaseCreatePayloadSchema
+>
+
+export const QBDepositLineSchema = z.union([
+  z.object({
+    Amount: z.number(),
+    LinkedTxn: z.array(
+      z.object({
+        TxnId: z.string(),
+        TxnType: z.literal('Payment'),
+      }),
+    ),
+  }),
+  z.object({
+    Amount: z.number(),
+    DetailType: z.literal('DepositLineDetail'),
+    DepositLineDetail: z.object({
+      AccountRef: QBNameValueSchema,
+    }),
+    Description: z.string().optional(),
+  }),
+])
+
+export const QBDepositCreatePayloadSchema = z.object({
+  DepositToAccountRef: z.object({
+    value: z.string(),
+  }),
+  TxnDate: z.string(),
+  Line: z.array(QBDepositLineSchema),
+})
+
+export type QBDepositCreatePayloadType = z.infer<
+  typeof QBDepositCreatePayloadSchema
 >
 
 export const QBDeletePayloadSchema = z.object({

--- a/src/utils/intuitAPI.ts
+++ b/src/utils/intuitAPI.ts
@@ -13,6 +13,7 @@ import {
   QBPaymentCreatePayloadType,
   QBAccountCreatePayloadType,
   QBPurchaseCreatePayloadType,
+  QBDepositCreatePayloadType,
   QBDeletePayloadType,
   QBDestructiveInvoicePayloadSchema,
   QBNameValueSchemaType,
@@ -43,6 +44,8 @@ export type IntuitAPITokensType = Pick<
   | 'assetAccountRef'
   | 'serviceItemRef'
   | 'clientFeeRef'
+  | 'undepositedFundsAccountRef'
+  | 'bankAccountRef'
 > & { isSuspended?: boolean }
 
 export type BaseResponseType = {
@@ -810,6 +813,36 @@ export default class IntuitAPI {
     return purchase
   }
 
+  async _createDeposit(payload: QBDepositCreatePayloadType) {
+    CustomLogger.info({
+      obj: { payload },
+      message: `IntuitAPI#createDeposit | Deposit create start for realmId: ${this.tokens.intuitRealmId}.`,
+    })
+    const url = `${intuitBaseUrl}/v3/company/${this.tokens.intuitRealmId}/deposit?minorversion=${intuitApiMinorVersion}`
+    const deposit = await this.postFetchWithHeaders(url, payload)
+
+    if (!deposit)
+      throw new APIError(
+        httpStatus.BAD_REQUEST,
+        'IntuitAPI#createDeposit | message = no response',
+      )
+
+    if (deposit?.Fault) {
+      CustomLogger.error({ obj: deposit.Fault?.Error, message: 'Error: ' })
+      throw new APIError(
+        deposit.Fault?.Error?.code || httpStatus.BAD_REQUEST,
+        `${IntuitAPIErrorMessage}createDeposit`,
+        deposit.Fault?.Error,
+      )
+    }
+
+    CustomLogger.info({
+      obj: { response: deposit.Deposit },
+      message: `IntuitAPI#createDeposit | Deposit created with Id = ${deposit.Deposit?.Id}.`,
+    })
+    return deposit
+  }
+
   async _deletePurchase(payload: QBDeletePayloadType) {
     CustomLogger.info({
       obj: { payload },
@@ -941,6 +974,7 @@ export default class IntuitAPI {
   createAccount = this.wrapWithRetry(this._createAccount)
   updateAccount = this.wrapWithRetry(this._updateAccount)
   createPurchase = this.wrapWithRetry(this._createPurchase)
+  createDeposit = this.wrapWithRetry(this._createDeposit)
   deletePayment = this.wrapWithRetry(this._deletePayment)
   deletePurchase = this.wrapWithRetry(this._deletePurchase)
   getCompanyInfo = this.wrapWithRetry(this._getCompanyInfo)


### PR DESCRIPTION
## Summary

- Adds QBO Bank Deposit creation when payments are received, so the deposit amount matches the net bank transaction (after Stripe fees)
- Payments are routed through "Undeposited Funds", then a Bank Deposit moves the net amount to the bank account with the fee as a negative line
- New opt-in `bankDepositFeeFlag` setting (requires `absorbedFeeFlag` to also be enabled) — no impact on existing customers

## Problem

Customers like Sedona (Permit Pushers) invoice $2,250 in Assembly but Stripe deposits only $2,241 after fees. The QBO invoice shows $2,250, so bank transactions can't be matched without manually editing every invoice in QuickBooks. See [customer call](https://app.sybill.ai/conversations/shared/01027de2-d0b7-4c7b-bc79-93928f58267e).

## Solution

Implements the standard "Undeposited Funds + Bank Deposit" accounting pattern:

1. **QBO Payment** ($2,250) → routed to Undeposited Funds (not directly to bank)
2. **QBO Bank Deposit** → pulls payment from Undeposited Funds, deducts $9 fee → deposits $2,241 to bank
3. **Bank feed** → QBO auto-matches the $2,241 deposit

## Changes

| Area | Files |
|------|-------|
| DB schema + migration | `qbSettings.ts`, `qbPortalConnections.ts`, migration SQL |
| QBO API | `intuitAPI.ts` (createDeposit), `intuitAPI.dto.ts` (Deposit schemas) |
| Payment flow | `invoice.service.ts` (DepositToAccountRef), `webhook.service.ts` (bank deposit creation), `payment.service.ts` (createBankDepositForPayment) |
| Account mgmt | `token.service.ts` (Undeposited Funds lookup), `qbConnection.ts` |
| Settings UI | `InvoiceDetail.tsx`, `useSettings.ts`, `common.ts`, `setting.controller.ts` |
| Types | `log.ts` (DEPOSITED event type) |

## Test plan

- [ ] Enable `absorbedFeeFlag` + `bankDepositFeeFlag` for a test workspace
- [ ] Configure a bank account ref in QBO settings
- [ ] Create and pay an invoice in Assembly
- [ ] Verify QBO: Invoice (gross), Payment (gross → Undeposited Funds), Bank Deposit (net → bank)
- [ ] Verify fee appears as negative line on Deposit against expense account
- [ ] Verify legacy flow still works when `bankDepositFeeFlag` is false
- [ ] Verify UI: checkbox is nested under absorbed fees, disappears when absorbed fees unchecked

Linear: OUT-3604

🤖 Generated with [Claude Code](https://claude.com/claude-code)