### PR TITLE
OUT-3597: refresh QBO token before fetching company info

### DIFF
--- a/src/action/quickbooks.action.ts
+++ b/src/action/quickbooks.action.ts
@@ -9,7 +9,7 @@ import {
 } from '@/db/service/token.service'
 import IntuitAPI from '@/utils/intuitAPI'
 import CustomLogger from '@/utils/logger'
-import { refreshAndPersistQBToken } from '@/utils/tokenRefresh'
+import { getRefreshedQbTokenInfo } from '@/utils/tokenRefresh'
 import dayjs from 'dayjs'
 import { z } from 'zod'
 
@@ -55,7 +55,7 @@ export async function checkForNonUsCompany(portalId: string) {
     dayjs().isAfter(dayjs(tokenSetTime).add(expiresIn, 'seconds'))
 
   const tokenInfo = isExpired
-    ? await refreshAndPersistQBToken(portalId)
+    ? await getRefreshedQbTokenInfo(portalId)
     : {
         accessToken: portalConnection.accessToken,
         refreshToken: portalConnection.refreshToken,

--- a/src/action/quickbooks.action.ts
+++ b/src/action/quickbooks.action.ts
@@ -9,6 +9,8 @@ import {
 } from '@/db/service/token.service'
 import IntuitAPI, { IntuitAPITokensType } from '@/utils/intuitAPI'
 import CustomLogger from '@/utils/logger'
+import { refreshAndPersistQBToken } from '@/utils/tokenRefresh'
+import dayjs from 'dayjs'
 import { z } from 'zod'
 
 export async function checkPortalConnection(
@@ -33,10 +35,59 @@ export async function checkSyncStatus(portalId: string): Promise<boolean> {
   }
 }
 
-export async function checkForNonUsCompany(tokenInfo: IntuitAPITokensType) {
+export async function checkForNonUsCompany(portalId: string) {
   CustomLogger.info({
     message: 'checkForNonUsCompany | Checking for non-US company',
   })
+
+  const portalConnection = await getPortalConnection(portalId)
+  if (!portalConnection) {
+    throw new Error(
+      `checkForNonUsCompany | Portal connection not found for portalId: ${portalId}`,
+    )
+  }
+
+  const {
+    accessToken,
+    refreshToken,
+    intuitRealmId,
+    tokenSetTime,
+    expiresIn,
+    incomeAccountRef,
+    expenseAccountRef,
+    assetAccountRef,
+    serviceItemRef,
+    clientFeeRef,
+  } = portalConnection
+
+  let tokenInfo: IntuitAPITokensType = {
+    accessToken,
+    refreshToken,
+    intuitRealmId,
+    incomeAccountRef,
+    expenseAccountRef,
+    assetAccountRef,
+    serviceItemRef,
+    clientFeeRef,
+  }
+
+  // Refresh token if expired (treat missing tokenSetTime as expired)
+  const isExpired =
+    !tokenSetTime ||
+    dayjs().isAfter(dayjs(tokenSetTime).add(expiresIn, 'seconds'))
+  if (isExpired) {
+    CustomLogger.info({
+      message:
+        'checkForNonUsCompany | Access token expired, refreshing token...',
+    })
+
+    tokenInfo = await refreshAndPersistQBToken(
+      portalId,
+      intuitRealmId,
+      tokenInfo,
+    )
+  }
+
   const intuitApi = new IntuitAPI(tokenInfo)
   const companyInfo = await intuitApi.getCompanyInfo()
 

--- a/src/action/quickbooks.action.ts
+++ b/src/action/quickbooks.action.ts
@@ -7,7 +7,7 @@ import {
   getPortalConnection,
   getPortalSettings,
 } from '@/db/service/token.service'
-import IntuitAPI, { IntuitAPITokensType } from '@/utils/intuitAPI'
+import IntuitAPI from '@/utils/intuitAPI'
 import CustomLogger from '@/utils/logger'
 import { refreshAndPersistQBToken } from '@/utils/tokenRefresh'
 import dayjs from 'dayjs'
@@ -47,46 +47,25 @@ export async function checkForNonUsCompany(portalId: string) {
     )
   }
 
-  const {
-    accessToken,
-    refreshToken,
-    intuitRealmId,
-    tokenSetTime,
-    expiresIn,
-    incomeAccountRef,
-    expenseAccountRef,
-    assetAccountRef,
-    serviceItemRef,
-    clientFeeRef,
-  } = portalConnection
-
-  let tokenInfo: IntuitAPITokensType = {
-    accessToken,
-    refreshToken,
-    intuitRealmId,
-    incomeAccountRef,
-    expenseAccountRef,
-    assetAccountRef,
-    serviceItemRef,
-    clientFeeRef,
-  }
+  const { tokenSetTime, expiresIn } = portalConnection
 
   // Refresh token if expired (treat missing tokenSetTime as expired)
   const isExpired =
     !tokenSetTime ||
     dayjs().isAfter(dayjs(tokenSetTime).add(expiresIn, 'seconds'))
-  if (isExpired) {
-    CustomLogger.info({
-      message:
-        'checkForNonUsCompany | Access token expired, refreshing token...',
-    })
 
-    tokenInfo = await refreshAndPersistQBToken(
-      portalId,
-      intuitRealmId,
-      tokenInfo,
-    )
-  }
+  const tokenInfo = isExpired
+    ? await refreshAndPersistQBToken(portalId)
+    : {
+        accessToken: portalConnection.accessToken,
+        refreshToken: portalConnection.refreshToken,
+        intuitRealmId: portalConnection.intuitRealmId,
+        incomeAccountRef: portalConnection.incomeAccountRef,
+        expenseAccountRef: portalConnection.expenseAccountRef,
+        assetAccountRef: portalConnection.assetAccountRef,
+        serviceItemRef: portalConnection.serviceItemRef,
+        clientFeeRef: portalConnection.clientFeeRef,
+      }
 
   const intuitApi = new IntuitAPI(tokenInfo)
   const companyInfo = await intuitApi.getCompanyInfo()

--- a/src/app/api/quickbooks/auth/auth.service.ts
+++ b/src/app/api/quickbooks/auth/auth.service.ts
@@ -286,11 +286,7 @@ export class AuthService extends BaseService {
     // Refresh token if expired
     if (dayjs().isAfter(expiryTime)) {
       try {
-        updatedTokenInfo = await refreshAndPersistQBToken(
-          portalId,
-          intuitRealmId,
-          updatedTokenInfo,
-        )
+        updatedTokenInfo = await refreshAndPersistQBToken(portalId)
       } catch (error: unknown) {
         console.error('AuthService#getQBPortalConnection | Error =', error)
 

--- a/src/app/api/quickbooks/auth/auth.service.ts
+++ b/src/app/api/quickbooks/auth/auth.service.ts
@@ -25,7 +25,7 @@ import dayjs from 'dayjs'
 import { eq } from 'drizzle-orm'
 import httpStatus from 'http-status'
 import { afterIfAvailable } from '@/app/api/core/utils/afterIfAvailable'
-import { refreshAndPersistQBToken } from '@/utils/tokenRefresh'
+import { getRefreshedQbTokenInfo } from '@/utils/tokenRefresh'
 import { after } from 'next/server'
 
 export class AuthService extends BaseService {
@@ -286,7 +286,7 @@ export class AuthService extends BaseService {
     // Refresh token if expired
     if (dayjs().isAfter(expiryTime)) {
       try {
-        updatedTokenInfo = await refreshAndPersistQBToken(portalId)
+        updatedTokenInfo = await getRefreshedQbTokenInfo(portalId)
       } catch (error: unknown) {
         console.error('AuthService#getQBPortalConnection | Error =', error)
 

--- a/src/app/api/quickbooks/auth/auth.service.ts
+++ b/src/app/api/quickbooks/auth/auth.service.ts
@@ -12,26 +12,20 @@ import { intuitRedirectUri } from '@/config'
 import { OAuthErrorCodes } from '@/constant/intuitErrorCode'
 import { AccountTypeObj } from '@/constant/qbConnection'
 import { ConnectionStatus } from '@/db/schema/qbConnectionLogs'
-import {
-  QBPortalConnection,
-  QBPortalConnectionCreateSchemaType,
-  QBPortalConnectionUpdateSchemaType,
-} from '@/db/schema/qbPortalConnections'
+import { QBPortalConnectionCreateSchemaType } from '@/db/schema/qbPortalConnections'
 import { QBSetting } from '@/db/schema/qbSettings'
 import {
   getPortalConnection,
   getPortalSettings,
 } from '@/db/service/token.service'
-import {
-  QBAuthTokenResponse,
-  QBAuthTokenResponseSchema,
-} from '@/type/dto/qbAuthToken.dto'
+import { QBAuthTokenResponseSchema } from '@/type/dto/qbAuthToken.dto'
 import Intuit from '@/utils/intuit'
 import IntuitAPI, { IntuitAPITokensType } from '@/utils/intuitAPI'
 import dayjs from 'dayjs'
-import { and, eq, SQL } from 'drizzle-orm'
+import { eq } from 'drizzle-orm'
 import httpStatus from 'http-status'
 import { afterIfAvailable } from '@/app/api/core/utils/afterIfAvailable'
+import { refreshAndPersistQBToken } from '@/utils/tokenRefresh'
 import { after } from 'next/server'
 
 export class AuthService extends BaseService {
@@ -291,44 +285,12 @@ export class AuthService extends BaseService {
 
     // Refresh token if expired
     if (dayjs().isAfter(expiryTime)) {
-      const tokenService = new TokenService(this.user)
       try {
-        const tokenInfo: QBAuthTokenResponse =
-          await Intuit.getInstance().getRefreshedQBToken(refreshToken)
-        const tokenSetTime = dayjs().toDate()
-
-        updatedTokenInfo = {
-          ...updatedTokenInfo,
-          accessToken: tokenInfo.access_token,
-          refreshToken: tokenInfo.refresh_token,
-        }
-
-        const updatedPayload: QBPortalConnectionUpdateSchemaType = {
-          accessToken: updatedTokenInfo.accessToken,
-          refreshToken: updatedTokenInfo.refreshToken,
-          expiresIn: tokenInfo.expires_in,
-          XRefreshTokenExpiresIn: tokenInfo.x_refresh_token_expires_in,
-          tokenSetTime,
-          updatedAt: dayjs().toDate(),
-        }
-
-        const whereConditions = and(
-          eq(QBPortalConnection.intuitRealmId, intuitRealmId),
-          eq(QBPortalConnection.portalId, portalId),
-        ) as SQL
-
-        const updateSync = await tokenService.updateQBPortalConnection(
-          updatedPayload,
-          whereConditions,
-          ['id'],
+        updatedTokenInfo = await refreshAndPersistQBToken(
+          portalId,
+          intuitRealmId,
+          updatedTokenInfo,
         )
-
-        if (!updateSync) {
-          throw new APIError(
-            httpStatus.INTERNAL_SERVER_ERROR,
-            `Cannot update sync status for portal ${portalId} and realmId ${intuitRealmId}.`,
-          )
-        }
       } catch (error: unknown) {
         console.error('AuthService#getQBPortalConnection | Error =', error)
 
@@ -342,6 +304,7 @@ export class AuthService extends BaseService {
           if (error.error === OAuthErrorCodes.INVALID_GRANT) {
             // indicates that the refresh token is invalid
             // turn off the sync and send notifications to IU (product and email)
+            const tokenService = new TokenService(this.user)
             await tokenService.turnOffSync(intuitRealmId)
 
             // send notification to IU

--- a/src/cmd/renameQbAccount/renameQbAccount.service.ts
+++ b/src/cmd/renameQbAccount/renameQbAccount.service.ts
@@ -1,16 +1,9 @@
 import { BaseService } from '@/app/api/core/services/base.service'
-import { TokenService } from '@/app/api/quickbooks/token/token.service'
-import {
-  PortalConnectionWithSettingType,
-  QBPortalConnection,
-  QBPortalConnectionUpdateSchemaType,
-} from '@/db/schema/qbPortalConnections'
+import { PortalConnectionWithSettingType } from '@/db/schema/qbPortalConnections'
 import { getAllActivePortalConnections } from '@/db/service/token.service'
-import Intuit from '@/utils/intuit'
 import IntuitAPI from '@/utils/intuitAPI'
 import CustomLogger from '@/utils/logger'
-import dayjs from 'dayjs'
-import { and, eq, SQL } from 'drizzle-orm'
+import { refreshAndPersistQBToken } from '@/utils/tokenRefresh'
 
 const assetAccountNameOld = 'Copilot General Asset'
 const assetAccountNameNew = 'Assembly General Asset'
@@ -158,30 +151,23 @@ export class RenameQbAccountService extends BaseService {
   private async handleRefreshToken() {
     try {
       const portal = RenameQbAccountService.connection
-      const tokenInfo = await Intuit.getInstance().getRefreshedQBToken(
-        portal.refreshToken,
-      )
-
-      const updatedPayload: QBPortalConnectionUpdateSchemaType = {
-        accessToken: tokenInfo.access_token,
-        refreshToken: tokenInfo.refresh_token,
-        expiresIn: tokenInfo.expires_in,
-        XRefreshTokenExpiresIn: tokenInfo.x_refresh_token_expires_in,
-        tokenSetTime: dayjs().toDate(),
+      const currentTokens = {
+        accessToken: portal.accessToken,
+        refreshToken: portal.refreshToken,
+        intuitRealmId: portal.intuitRealmId,
+        incomeAccountRef: portal.incomeAccountRef,
+        expenseAccountRef: portal.expenseAccountRef,
+        assetAccountRef: portal.assetAccountRef,
+        serviceItemRef: portal.serviceItemRef,
+        clientFeeRef: portal.clientFeeRef,
       }
 
-      const whereConditions = and(
-        eq(QBPortalConnection.intuitRealmId, portal.intuitRealmId),
-        eq(QBPortalConnection.portalId, portal.portalId),
-      ) as SQL
-
-      const tokenService = new TokenService(this.user)
-      await tokenService.updateQBPortalConnection(
-        updatedPayload,
-        whereConditions,
-        ['id'],
+      await refreshAndPersistQBToken(
+        portal.portalId,
+        portal.intuitRealmId,
+        currentTokens,
       )
-      console.info('Access token refreshed and updated in DB 🔥')
+      console.info('Access token refreshed and updated in DB')
     } catch (error: unknown) {
       console.error('Issue while refreshing token')
       CustomLogger.error({

--- a/src/cmd/renameQbAccount/renameQbAccount.service.ts
+++ b/src/cmd/renameQbAccount/renameQbAccount.service.ts
@@ -1,7 +1,7 @@
 import { BaseService } from '@/app/api/core/services/base.service'
 import { PortalConnectionWithSettingType } from '@/db/schema/qbPortalConnections'
 import { getAllActivePortalConnections } from '@/db/service/token.service'
-import IntuitAPI from '@/utils/intuitAPI'
+import IntuitAPI, { IntuitAPITokensType } from '@/utils/intuitAPI'
 import CustomLogger from '@/utils/logger'
 import { refreshAndPersistQBToken } from '@/utils/tokenRefresh'
 
@@ -41,19 +41,9 @@ export class RenameQbAccountService extends BaseService {
   }
 
   async processAccountRename() {
+    const freshTokens = await this.handleRefreshToken()
+    const intuitApi = new IntuitAPI(freshTokens)
     const portal = RenameQbAccountService.connection
-    const qbTokenInfo = {
-      accessToken: portal.accessToken,
-      refreshToken: portal.refreshToken,
-      intuitRealmId: portal.intuitRealmId,
-      incomeAccountRef: portal.incomeAccountRef,
-      expenseAccountRef: portal.expenseAccountRef,
-      assetAccountRef: portal.assetAccountRef,
-      serviceItemRef: portal.serviceItemRef,
-      clientFeeRef: portal.clientFeeRef,
-    }
-    const intuitApi = new IntuitAPI(qbTokenInfo)
-    await this.handleRefreshToken()
 
     let renameAssetAccount, renameExpenseAccount, renameClientFeeAccount
 
@@ -148,10 +138,21 @@ export class RenameQbAccountService extends BaseService {
     }
   }
 
-  private async handleRefreshToken() {
+  private async handleRefreshToken(): Promise<IntuitAPITokensType> {
+    const portal = RenameQbAccountService.connection
     try {
-      const portal = RenameQbAccountService.connection
-      const currentTokens = {
+      const freshTokens = await refreshAndPersistQBToken(portal.portalId)
+      console.info('Access token refreshed and updated in DB')
+      return freshTokens
+    } catch (error: unknown) {
+      console.error('Issue while refreshing token')
+      CustomLogger.error({
+        message: 'RenameQbAccountService#handleRefreshToken',
+        obj: { error },
+      })
+
+      // Fall back to existing tokens so the process can still attempt the rename
+      return {
         accessToken: portal.accessToken,
         refreshToken: portal.refreshToken,
         intuitRealmId: portal.intuitRealmId,
@@ -161,19 +162,6 @@ export class RenameQbAccountService extends BaseService {
         serviceItemRef: portal.serviceItemRef,
         clientFeeRef: portal.clientFeeRef,
       }
-
-      await refreshAndPersistQBToken(
-        portal.portalId,
-        portal.intuitRealmId,
-        currentTokens,
-      )
-      console.info('Access token refreshed and updated in DB')
-    } catch (error: unknown) {
-      console.error('Issue while refreshing token')
-      CustomLogger.error({
-        message: 'RenameQbAccountService#handleRefreshToken',
-        obj: { error },
-      })
     }
   }
 }

--- a/src/cmd/renameQbAccount/renameQbAccount.service.ts
+++ b/src/cmd/renameQbAccount/renameQbAccount.service.ts
@@ -3,7 +3,7 @@ import { PortalConnectionWithSettingType } from '@/db/schema/qbPortalConnections
 import { getAllActivePortalConnections } from '@/db/service/token.service'
 import IntuitAPI, { IntuitAPITokensType } from '@/utils/intuitAPI'
 import CustomLogger from '@/utils/logger'
-import { refreshAndPersistQBToken } from '@/utils/tokenRefresh'
+import { getRefreshedQbTokenInfo } from '@/utils/tokenRefresh'
 
 const assetAccountNameOld = 'Copilot General Asset'
 const assetAccountNameNew = 'Assembly General Asset'
@@ -141,7 +141,7 @@ export class RenameQbAccountService extends BaseService {
   private async handleRefreshToken(): Promise<IntuitAPITokensType> {
     const portal = RenameQbAccountService.connection
     try {
-      const freshTokens = await refreshAndPersistQBToken(portal.portalId)
+      const freshTokens = await getRefreshedQbTokenInfo(portal.portalId)
       console.info('Access token refreshed and updated in DB')
       return freshTokens
     } catch (error: unknown) {

--- a/src/hook/useDashboard.ts
+++ b/src/hook/useDashboard.ts
@@ -3,7 +3,6 @@ import { checkForNonUsCompany } from '@/action/quickbooks.action'
 import { AuthStatus } from '@/app/api/core/types/auth'
 import { useApp } from '@/app/context/AppContext'
 import { CalloutVariant } from '@/components/type/callout'
-import { getPortalTokens } from '@/db/service/token.service'
 import { useQuickbooks } from '@/hook/useQuickbooks'
 import { useCallback, useEffect, useState } from 'react'
 
@@ -16,7 +15,6 @@ export const useDashboardMain = () => {
     lastSyncTimestamp,
     isEnabled,
     portalConnectionStatus,
-    qbTokens,
     setAppParams,
   } = useApp()
 
@@ -41,18 +39,17 @@ export const useDashboardMain = () => {
 
   const checkCompanyCountry = useCallback(async () => {
     setNonUsCompanyChecking(true)
-    let tempTokenInfo = qbTokens
-    if (!tempTokenInfo) {
-      tempTokenInfo = await getPortalTokens(tokenPayload.workspaceId)
+    try {
+      const nonUsCompany = await checkForNonUsCompany(tokenPayload.workspaceId)
+      setAppParams((prev) => ({
+        ...prev,
+        nonUsCompany,
+      }))
+    } catch (err) {
+      console.error('checkCompanyCountry | Error =', err)
+    } finally {
+      setNonUsCompanyChecking(false)
     }
-
-    const nonUsCompany = await checkForNonUsCompany(tempTokenInfo)
-    setAppParams((prev) => ({
-      ...prev,
-      qbTokens: tempTokenInfo,
-      nonUsCompany,
-    }))
-    setNonUsCompanyChecking(false)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [syncFlag])
 

--- a/src/utils/tokenRefresh.ts
+++ b/src/utils/tokenRefresh.ts
@@ -1,0 +1,61 @@
+import {
+  QBPortalConnection,
+  QBPortalConnectionUpdateSchemaType,
+} from '@/db/schema/qbPortalConnections'
+import Intuit from '@/utils/intuit'
+import { IntuitAPITokensType } from '@/utils/intuitAPI'
+import { db } from '@/db'
+import { and, eq } from 'drizzle-orm'
+import dayjs from 'dayjs'
+
+/**
+ * Refreshes a QBO access token via the Intuit SDK and persists
+ * the new token set back to `qb_portal_connections`.
+ *
+ * Callers are responsible for:
+ * - Deciding *when* to refresh (e.g. checking expiry first).
+ * - Handling domain-specific errors (e.g. INVALID_GRANT → turn off sync).
+ */
+export async function refreshAndPersistQBToken(
+  portalId: string,
+  intuitRealmId: string,
+  currentTokens: IntuitAPITokensType,
+): Promise<IntuitAPITokensType> {
+  const refreshedToken = await Intuit.getInstance().getRefreshedQBToken(
+    currentTokens.refreshToken,
+  )
+
+  const updatedTokens: IntuitAPITokensType = {
+    ...currentTokens,
+    accessToken: refreshedToken.access_token,
+    refreshToken: refreshedToken.refresh_token,
+  }
+
+  const updatedPayload: QBPortalConnectionUpdateSchemaType = {
+    accessToken: updatedTokens.accessToken,
+    refreshToken: updatedTokens.refreshToken,
+    expiresIn: refreshedToken.expires_in,
+    XRefreshTokenExpiresIn: refreshedToken.x_refresh_token_expires_in,
+    tokenSetTime: dayjs().toDate(),
+    updatedAt: dayjs().toDate(),
+  }
+
+  const [updated] = await db
+    .update(QBPortalConnection)
+    .set(updatedPayload)
+    .where(
+      and(
+        eq(QBPortalConnection.intuitRealmId, intuitRealmId),
+        eq(QBPortalConnection.portalId, portalId),
+      ),
+    )
+    .returning({ id: QBPortalConnection.id })
+
+  if (!updated) {
+    throw new Error(
+      `refreshAndPersistQBToken | No row updated for portalId=${portalId}, realmId=${intuitRealmId}`,
+    )
+  }
+
+  return updatedTokens
+}

--- a/src/utils/tokenRefresh.ts
+++ b/src/utils/tokenRefresh.ts
@@ -22,13 +22,13 @@ import dayjs from 'dayjs'
  * - Deciding *when* to refresh (e.g. checking expiry first).
  * - Handling domain-specific errors (e.g. INVALID_GRANT → turn off sync).
  */
-export async function refreshAndPersistQBToken(
+export async function getRefreshedQbTokenInfo(
   portalId: string,
 ): Promise<IntuitAPITokensType> {
   const portalConnection = await getPortalConnection(portalId)
   if (!portalConnection) {
     throw new Error(
-      `refreshAndPersistQBToken | Portal connection not found for portalId: ${portalId}`,
+      `getRefreshedQbTokenInfo | Portal connection not found for portalId: ${portalId}`,
     )
   }
 
@@ -43,7 +43,7 @@ export async function refreshAndPersistQBToken(
   } = portalConnection
 
   CustomLogger.info({
-    message: `refreshAndPersistQBToken | Refreshing access token for portalId: ${portalId}`,
+    message: `getRefreshedQbTokenInfo | Refreshing access token for portalId: ${portalId}`,
   })
 
   const refreshedToken =
@@ -82,7 +82,7 @@ export async function refreshAndPersistQBToken(
 
   if (!updated) {
     throw new Error(
-      `refreshAndPersistQBToken | No row updated for portalId=${portalId}, realmId=${intuitRealmId}`,
+      `getRefreshedQbTokenInfo | No row updated for portalId=${portalId}, realmId=${intuitRealmId}`,
     )
   }
 

--- a/src/utils/tokenRefresh.ts
+++ b/src/utils/tokenRefresh.ts
@@ -2,8 +2,10 @@ import {
   QBPortalConnection,
   QBPortalConnectionUpdateSchemaType,
 } from '@/db/schema/qbPortalConnections'
+import { getPortalConnection } from '@/db/service/token.service'
 import Intuit from '@/utils/intuit'
 import { IntuitAPITokensType } from '@/utils/intuitAPI'
+import CustomLogger from '@/utils/logger'
 import { db } from '@/db'
 import { and, eq } from 'drizzle-orm'
 import dayjs from 'dayjs'
@@ -12,23 +14,50 @@ import dayjs from 'dayjs'
  * Refreshes a QBO access token via the Intuit SDK and persists
  * the new token set back to `qb_portal_connections`.
  *
+ * Fetches the portal connection internally — callers only need to
+ * supply the portalId (an extra DB read on the refresh path is
+ * acceptable given the Intuit API call that follows).
+ *
  * Callers are responsible for:
  * - Deciding *when* to refresh (e.g. checking expiry first).
  * - Handling domain-specific errors (e.g. INVALID_GRANT → turn off sync).
  */
 export async function refreshAndPersistQBToken(
   portalId: string,
-  intuitRealmId: string,
-  currentTokens: IntuitAPITokensType,
 ): Promise<IntuitAPITokensType> {
-  const refreshedToken = await Intuit.getInstance().getRefreshedQBToken(
-    currentTokens.refreshToken,
-  )
+  const portalConnection = await getPortalConnection(portalId)
+  if (!portalConnection) {
+    throw new Error(
+      `refreshAndPersistQBToken | Portal connection not found for portalId: ${portalId}`,
+    )
+  }
+
+  const {
+    refreshToken,
+    intuitRealmId,
+    incomeAccountRef,
+    expenseAccountRef,
+    assetAccountRef,
+    serviceItemRef,
+    clientFeeRef,
+  } = portalConnection
+
+  CustomLogger.info({
+    message: `refreshAndPersistQBToken | Refreshing access token for portalId: ${portalId}`,
+  })
+
+  const refreshedToken =
+    await Intuit.getInstance().getRefreshedQBToken(refreshToken)
 
   const updatedTokens: IntuitAPITokensType = {
-    ...currentTokens,
     accessToken: refreshedToken.access_token,
     refreshToken: refreshedToken.refresh_token,
+    intuitRealmId,
+    incomeAccountRef,
+    expenseAccountRef,
+    assetAccountRef,
+    serviceItemRef,
+    clientFeeRef,
   }
 
   const updatedPayload: QBPortalConnectionUpdateSchemaType = {


### PR DESCRIPTION
## Summary
- **Bug fix**: `checkForNonUsCompany` was called with potentially expired QBO access tokens because the client-side hook (`useDashboard`) passed raw DB tokens without checking expiry, causing "No company info found" errors.
- **Refactor**: Extracted the duplicated token refresh-and-persist logic (previously copy-pasted in `auth.service`, `quickbooks.action`, and `renameQbAccount.service`) into a shared `refreshAndPersistQBToken` utility in `src/utils/tokenRefresh.ts`.
- **Resilience**: Added `try/catch/finally` in `useDashboard` so the UI doesn't get stuck in a loading state if the server action throws, and added a null guard for `tokenSetTime`.

## Changes
| File | What changed |
|------|-------------|
| `src/utils/tokenRefresh.ts` (new) | Shared utility — refreshes via Intuit SDK, persists to DB, verifies row was updated |
| `src/action/quickbooks.action.ts` | `checkForNonUsCompany` now accepts `portalId`, fetches connection server-side, checks expiry, refreshes if needed |
| `src/hook/useDashboard.ts` | Passes `workspaceId` instead of raw tokens; added error handling |
| `src/app/api/quickbooks/auth/auth.service.ts` | Replaced inline refresh logic with `refreshAndPersistQBToken`; cleaned up unused imports |
| `src/cmd/renameQbAccount/renameQbAccount.service.ts` | Same — replaced inline refresh with utility call; cleaned up imports |

## Test plan
- [ ] Verify dashboard loads correctly for a portal with a valid (non-expired) QBO token
- [ ] Verify dashboard loads correctly for a portal with an expired QBO access token (token gets refreshed transparently)
- [ ] Verify webhook processing still works (uses `auth.service.ts` path)
- [ ] Verify non-US company detection still works correctly after token refresh
- [ ] Confirm no "No company info found" errors in Sentry after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)