### PR TITLE
fix(OUT-3607): return empty array when QB has no service items

### DIFF
--- a/src/utils/intuitAPI.ts
+++ b/src/utils/intuitAPI.ts
@@ -412,7 +412,7 @@ export default class IntuitAPI {
       )
     }
 
-    return QBItemsResponseSchema.parse(qbItems.Item ?? [])
+    return QBItemsResponseSchema.parse(qbItems.Item || [])
   }
 
   async _invoiceSparseUpdate(payload: QBInvoiceSparseUpdatePayloadType) {

--- a/src/utils/intuitAPI.ts
+++ b/src/utils/intuitAPI.ts
@@ -412,7 +412,7 @@ export default class IntuitAPI {
       )
     }
 
-    return QBItemsResponseSchema.parse(qbItems.Item)
+    return QBItemsResponseSchema.parse(qbItems.Item ?? [])
   }
 
   async _invoiceSparseUpdate(payload: QBInvoiceSparseUpdatePayloadType) {


### PR DESCRIPTION
## Summary
- `GET /api/quickbooks/product/qb/item` threw `ZodError: expected array, received undefined` when a QuickBooks company had zero Service items — QB omits the `Item` key from `QueryResponse` on empty result sets, so `QBItemsResponseSchema.parse(qbItems.Item)` received `undefined`.
- Fixed by defaulting to `[]` before parsing in `_getAllItems` (`src/utils/intuitAPI.ts:415`). Both callers (`product.service.ts#queryItemsFromQB`, `backfillProductInfo.service.ts`) already tolerate an empty array.

Fixes ACCOUNTING-SYNC-2X · Linear [OUT-3607](https://linear.app/assemblycom/issue/OUT-3607)

## Test plan
- [ ] Verify `/api/quickbooks/product/qb/item` returns `[]` (not 500) for a QB sandbox company with no Service items.
- [ ] Regression check: a company with ≥1 Service item still returns the parsed array.
- [ ] Backfill command tolerates the `[]` return (short-circuits via `allQbItems?.find`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)