### PR TITLE
OUT-3625: suffix DisplayName on QB Vendor/Employee collision

### DIFF
--- a/src/app/api/quickbooks/customer/customer.service.ts
+++ b/src/app/api/quickbooks/customer/customer.service.ts
@@ -16,7 +16,7 @@ import { InvoiceCreatedResponseType } from '@/type/dto/webhook.dto'
 import { CopilotAPI } from '@/utils/copilotAPI'
 import IntuitAPI from '@/utils/intuitAPI'
 import { addSyncBreadcrumb } from '@/utils/sentry'
-import { getNameAsCustomer, replaceSpecialCharsForQB } from '@/utils/string'
+import { replaceSpecialCharsForQB } from '@/utils/string'
 import { and, eq, isNull } from 'drizzle-orm'
 import httpStatus from 'http-status'
 
@@ -375,20 +375,17 @@ export class CustomerService extends BaseService {
       console.info(
         `InvoiceService#WebhookInvoiceCreated | Customer named ${recipientInfo.displayName} not found in QB. Creating new customer...`,
       )
-      // Create a new customer in QB
-      const sanitizedDisplayName = replaceSpecialCharsForQB(displayName)
-
+      // Create a new customer in QB.
       // QB enforces DisplayName uniqueness across Customer, Vendor, and Employee.
-      // If the name collides with a Vendor/Employee, suffix it to avoid error 6240.
-      const collision =
-        await intuitApiService.getNameCollisionEntity(sanitizedDisplayName)
-      const finalDisplayName = collision
-        ? getNameAsCustomer(sanitizedDisplayName)
-        : sanitizedDisplayName
+      // Resolve a free DisplayName up-front to avoid 6240/6200 errors when the
+      // base name or its "(Customer)" suffixed form is already taken.
+      const sanitizedDisplayName = replaceSpecialCharsForQB(displayName)
+      const finalDisplayName =
+        await intuitApiService.resolveUniqueCustomerName(sanitizedDisplayName)
 
-      if (collision) {
+      if (finalDisplayName !== sanitizedDisplayName) {
         console.info(
-          `InvoiceService#WebhookInvoiceCreated | DisplayName "${sanitizedDisplayName}" collides with existing ${collision.type} (Id: ${collision.id}). Using "${finalDisplayName}" instead.`,
+          `InvoiceService#WebhookInvoiceCreated | DisplayName "${sanitizedDisplayName}" was taken; resolved to "${finalDisplayName}".`,
         )
       }
 

--- a/src/app/api/quickbooks/customer/customer.service.ts
+++ b/src/app/api/quickbooks/customer/customer.service.ts
@@ -16,7 +16,7 @@ import { InvoiceCreatedResponseType } from '@/type/dto/webhook.dto'
 import { CopilotAPI } from '@/utils/copilotAPI'
 import IntuitAPI from '@/utils/intuitAPI'
 import { addSyncBreadcrumb } from '@/utils/sentry'
-import { replaceSpecialCharsForQB } from '@/utils/string'
+import { getNameAsCustomer, replaceSpecialCharsForQB } from '@/utils/string'
 import { and, eq, isNull } from 'drizzle-orm'
 import httpStatus from 'http-status'
 
@@ -376,8 +376,24 @@ export class CustomerService extends BaseService {
         `InvoiceService#WebhookInvoiceCreated | Customer named ${recipientInfo.displayName} not found in QB. Creating new customer...`,
       )
       // Create a new customer in QB
+      const sanitizedDisplayName = replaceSpecialCharsForQB(displayName)
+
+      // QB enforces DisplayName uniqueness across Customer, Vendor, and Employee.
+      // If the name collides with a Vendor/Employee, suffix it to avoid error 6240.
+      const collision =
+        await intuitApiService.getNameCollisionEntity(sanitizedDisplayName)
+      const finalDisplayName = collision
+        ? getNameAsCustomer(sanitizedDisplayName)
+        : sanitizedDisplayName
+
+      if (collision) {
+        console.info(
+          `InvoiceService#WebhookInvoiceCreated | DisplayName "${sanitizedDisplayName}" collides with existing ${collision.type} (Id: ${collision.id}). Using "${finalDisplayName}" instead.`,
+        )
+      }
+
       let customerPayload: QBCustomerCreatePayloadType = {
-        DisplayName: replaceSpecialCharsForQB(displayName),
+        DisplayName: finalDisplayName,
         CompanyName: companyInfo && replaceSpecialCharsForQB(companyInfo.name),
         PrimaryEmailAddr: {
           Address: recipientInfo.email,
@@ -404,6 +420,9 @@ export class CustomerService extends BaseService {
     }
 
     // create map for customer into mapping table
+    // NOTE: displayName here is the Copilot-side name (may differ from the QB
+    // DisplayName when a collision suffix was applied). The source of truth
+    // for the QB record's DisplayName is QB itself (fetched via qbCustomerId).
     const customerSync = await this.createQBCustomer({
       portalId: this.user.workspaceId,
       customerId: recipientInfo.recipientId, // TODO: remove everything related to this field. in case anything goes off the track

--- a/src/utils/intuitAPI.ts
+++ b/src/utils/intuitAPI.ts
@@ -28,7 +28,7 @@ import {
   QBItemsResponseSchema,
   SingleIdAndTokenResponseSchema,
 } from '@/type/dto/intuitAPI.dto'
-import { escapeForQBQuery } from '@/utils/string'
+import { escapeForQBQuery, getNameAsCustomer } from '@/utils/string'
 import { RetryableError } from '@/utils/error'
 import CustomLogger from '@/utils/logger'
 import httpStatus from 'http-status'
@@ -62,6 +62,11 @@ export type ItemResponseType = BaseResponseType & {
 }
 
 export const IntuitAPIErrorMessage = '#IntuitAPIErrorMessage#'
+
+// Upper bound on the " (Customer) N" suffix counter when resolving a unique
+// DisplayName. If exceeded, creation is aborted and a human is paged — having
+// 20+ Copilot clients sharing a single display name is pathological.
+const CUSTOMER_NAME_MAX_CANDIDATES = 20
 
 export default class IntuitAPI {
   tokens: IntuitAPITokensType
@@ -308,36 +313,70 @@ export default class IntuitAPI {
   }
 
   /**
-   * QB enforces DisplayName uniqueness across Customer, Vendor, and Employee.
-   * Returns the colliding entity's type and Id, or null if no Vendor/Employee
-   * collision exists.
+   * Resolves a DisplayName that is free across Customer, Vendor, and Employee
+   * (QBO enforces uniqueness across all three). Tries the baseName first, then
+   * "baseName (Customer)", "baseName (Customer) 2", ..., up to
+   * CUSTOMER_NAME_MAX_CANDIDATES. Queries all three entities in parallel with
+   * DisplayName IN (...) and picks the first candidate not in the returned set.
+   *
+   * Inactive records are intentionally excluded: QBO auto-suffixes their
+   * DisplayName with " (deleted)" when deactivated, freeing the original name.
+   *
+   * Intentionally NOT wrapped in wrapWithRetry — the inner customQuery calls
+   * already retry on 429; re-wrapping would amplify rate-limit bursts (worst
+   * case 4 × 3 × 4 = 48 requests) and make recovery worse.
+   *
+   * Throws if every candidate is taken.
    */
-  async _getNameCollisionEntity(
-    displayName: string,
-  ): Promise<{ type: 'Vendor' | 'Employee'; id: string } | null> {
-    const sanitizedDisplayName = escapeForQBQuery(displayName.trim())
+  async resolveUniqueCustomerName(baseName: string): Promise<string> {
+    const suffixed = getNameAsCustomer(baseName)
+    const candidates = [baseName, suffixed]
+    for (let i = 2; i <= CUSTOMER_NAME_MAX_CANDIDATES; i++) {
+      candidates.push(`${suffixed} ${i}`)
+    }
+
+    const escapedList = candidates
+      .map((c) => `'${escapeForQBQuery(c)}'`)
+      .join(', ')
 
     CustomLogger.info({
-      message: `IntuitAPI#getNameCollisionEntity | Collision check start for realmId: ${this.tokens.intuitRealmId}. Name: ${displayName}`,
+      message: `IntuitAPI#resolveUniqueCustomerName | Resolving unique DisplayName for realmId: ${this.tokens.intuitRealmId}. Base: "${baseName}"`,
     })
 
-    // QBO auto-suffixes inactive records' DisplayName with " (deleted)", freeing
-    // the original name, so only active records can actually collide.
-    const vendorQuery = `SELECT Id FROM Vendor WHERE DisplayName = '${sanitizedDisplayName}' maxresults 1`
-    const vendorRes = await this.customQuery(vendorQuery)
+    const [customerRes, vendorRes, employeeRes] = await Promise.all([
+      this.customQuery(
+        `SELECT DisplayName FROM Customer WHERE DisplayName IN (${escapedList})`,
+      ),
+      this.customQuery(
+        `SELECT DisplayName FROM Vendor WHERE DisplayName IN (${escapedList})`,
+      ),
+      this.customQuery(
+        `SELECT DisplayName FROM Employee WHERE DisplayName IN (${escapedList})`,
+      ),
+    ])
 
-    if (vendorRes?.Vendor?.length) {
-      return { type: 'Vendor', id: vendorRes.Vendor[0].Id }
+    // Case-insensitive comparison: QBO's DisplayName equality is case-
+    // insensitive, so a returned record may differ in case from our candidate.
+    const usedNames = new Set<string>()
+    for (const c of customerRes?.Customer ?? []) {
+      usedNames.add(c.DisplayName.toLowerCase())
+    }
+    for (const v of vendorRes?.Vendor ?? []) {
+      usedNames.add(v.DisplayName.toLowerCase())
+    }
+    for (const e of employeeRes?.Employee ?? []) {
+      usedNames.add(e.DisplayName.toLowerCase())
     }
 
-    const employeeQuery = `SELECT Id FROM Employee WHERE DisplayName = '${sanitizedDisplayName}' maxresults 1`
-    const employeeRes = await this.customQuery(employeeQuery)
-
-    if (employeeRes?.Employee?.length) {
-      return { type: 'Employee', id: employeeRes.Employee[0].Id }
+    const freeName = candidates.find((c) => !usedNames.has(c.toLowerCase()))
+    if (!freeName) {
+      throw new APIError(
+        httpStatus.CONFLICT,
+        `${IntuitAPIErrorMessage}resolveUniqueCustomerName | All ${CUSTOMER_NAME_MAX_CANDIDATES} candidate names are taken for base "${baseName}"`,
+      )
     }
 
-    return null
+    return freeName
   }
 
   /**
@@ -854,7 +893,6 @@ export default class IntuitAPI {
     ): Promise<CustomerQueryResponseType>
   } = this.wrapWithRetry(this._getACustomer) as any
   getCustomerByEmail = this.wrapWithRetry(this._getCustomerByEmail)
-  getNameCollisionEntity = this.wrapWithRetry(this._getNameCollisionEntity)
   getAnItem: {
     (
       name: string,

--- a/src/utils/intuitAPI.ts
+++ b/src/utils/intuitAPI.ts
@@ -238,18 +238,6 @@ export default class IntuitAPI {
         'IntuitAPI#getSingleIncomeAccount | Income account not found',
       )
 
-    if (qbIncomeAccountRefInfo?.Fault) {
-      CustomLogger.error({
-        obj: qbIncomeAccountRefInfo.Fault?.Error,
-        message: 'Error: ',
-      })
-      throw new APIError(
-        qbIncomeAccountRefInfo.Fault?.Error?.code || httpStatus.BAD_REQUEST,
-        `${IntuitAPIErrorMessage}getSingleIncomeAccount`,
-        qbIncomeAccountRefInfo.Fault?.Error,
-      )
-    }
-
     return qbIncomeAccountRefInfo.Account?.[0]
   }
 
@@ -299,15 +287,6 @@ export default class IntuitAPI {
 
     if (!qbCustomers) return null
 
-    if (qbCustomers?.Fault) {
-      CustomLogger.error({ obj: qbCustomers.Fault?.Error, message: 'Error: ' })
-      throw new APIError(
-        qbCustomers.Fault?.Error?.code || httpStatus.BAD_REQUEST,
-        `${IntuitAPIErrorMessage}getACustomer`,
-        qbCustomers.Fault?.Error,
-      )
-    }
-
     if (!qbCustomers.Customer) return
     return CustomerQueryResponseSchema.parse(qbCustomers.Customer[0])
   }
@@ -323,15 +302,6 @@ export default class IntuitAPI {
     const qbCustomers = await this.customQuery(customerQuery)
 
     if (!qbCustomers) return
-
-    if (qbCustomers?.Fault) {
-      CustomLogger.error({ obj: qbCustomers.Fault?.Error, message: 'Error: ' })
-      throw new APIError(
-        qbCustomers.Fault?.Error?.code || httpStatus.BAD_REQUEST,
-        `${IntuitAPIErrorMessage}getCustomerByEmail`,
-        qbCustomers.Fault?.Error,
-      )
-    }
 
     if (!qbCustomers.Customer) return
     return CustomerQueryResponseSchema.parse(qbCustomers.Customer[0])
@@ -410,15 +380,6 @@ export default class IntuitAPI {
 
     if (!qbItem) return null
 
-    if (qbItem?.Fault) {
-      CustomLogger.error({ obj: qbItem.Fault?.Error, message: 'Error: ' })
-      throw new APIError(
-        qbItem.Fault?.Error?.code || httpStatus.BAD_REQUEST,
-        `${IntuitAPIErrorMessage}getAnItem`,
-        qbItem.Fault?.Error,
-      )
-    }
-
     return qbItem.Item?.[0]
   }
 
@@ -435,15 +396,6 @@ export default class IntuitAPI {
     const qbItems = await this.customQuery(customerQuery)
 
     if (!qbItems) return null
-
-    if (qbItems?.Fault) {
-      CustomLogger.error({ obj: qbItems.Fault?.Error, message: 'Error: ' })
-      throw new APIError(
-        qbItems.Fault?.Error?.code || httpStatus.BAD_REQUEST,
-        `${IntuitAPIErrorMessage}getAllItems`,
-        qbItems.Fault?.Error,
-      )
-    }
 
     return QBItemsResponseSchema.parse(qbItems.Item || [])
   }
@@ -622,15 +574,6 @@ export default class IntuitAPI {
         'IntuitAPI#getInvoice | message = no response',
       )
 
-    if (invoice?.Fault) {
-      CustomLogger.error({ obj: invoice.Fault?.Error, message: 'Error: ' })
-      throw new APIError(
-        invoice.Fault?.Error?.code || httpStatus.BAD_REQUEST,
-        `${IntuitAPIErrorMessage}getInvoice`,
-        invoice.Fault?.Error,
-      )
-    }
-
     if (!invoice.Invoice) return null
 
     CustomLogger.info({
@@ -771,15 +714,6 @@ export default class IntuitAPI {
 
     if (!customQuery) return null
 
-    if (customQuery?.Fault) {
-      CustomLogger.error({ obj: customQuery.Fault?.Error, message: 'Error: ' })
-      throw new APIError(
-        customQuery.Fault?.Error?.code || httpStatus.BAD_REQUEST,
-        `${IntuitAPIErrorMessage}getAnAccount`,
-        customQuery.Fault?.Error,
-      )
-    }
-
     return customQuery.Account?.[0]
   }
 
@@ -886,15 +820,6 @@ export default class IntuitAPI {
         'No company info found',
         true,
       )
-
-    if (companyInfo.Fault) {
-      CustomLogger.error({ obj: companyInfo.Fault?.Error, message: 'Error: ' })
-      throw new APIError(
-        companyInfo.Fault?.Error?.code || httpStatus.BAD_REQUEST,
-        `${IntuitAPIErrorMessage}getCompanyInfo`,
-        companyInfo.Fault?.Error,
-      )
-    }
 
     const parsedCompanyInfo = CompanyInfoSchema.parse(companyInfo)
     return parsedCompanyInfo.CompanyInfo[0]

--- a/src/utils/intuitAPI.ts
+++ b/src/utils/intuitAPI.ts
@@ -338,6 +338,39 @@ export default class IntuitAPI {
   }
 
   /**
+   * QB enforces DisplayName uniqueness across Customer, Vendor, and Employee.
+   * Returns the colliding entity's type and Id, or null if no Vendor/Employee
+   * collision exists.
+   */
+  async _getNameCollisionEntity(
+    displayName: string,
+  ): Promise<{ type: 'Vendor' | 'Employee'; id: string } | null> {
+    const sanitizedDisplayName = escapeForQBQuery(displayName.trim())
+
+    CustomLogger.info({
+      message: `IntuitAPI#getNameCollisionEntity | Collision check start for realmId: ${this.tokens.intuitRealmId}. Name: ${displayName}`,
+    })
+
+    // QBO auto-suffixes inactive records' DisplayName with " (deleted)", freeing
+    // the original name, so only active records can actually collide.
+    const vendorQuery = `SELECT Id FROM Vendor WHERE DisplayName = '${sanitizedDisplayName}' maxresults 1`
+    const vendorRes = await this.customQuery(vendorQuery)
+
+    if (vendorRes?.Vendor?.length) {
+      return { type: 'Vendor', id: vendorRes.Vendor[0].Id }
+    }
+
+    const employeeQuery = `SELECT Id FROM Employee WHERE DisplayName = '${sanitizedDisplayName}' maxresults 1`
+    const employeeRes = await this.customQuery(employeeQuery)
+
+    if (employeeRes?.Employee?.length) {
+      return { type: 'Employee', id: employeeRes.Employee[0].Id }
+    }
+
+    return null
+  }
+
+  /**
    * Either name or id must be provided
    */
   async _getAnItem(
@@ -896,6 +929,7 @@ export default class IntuitAPI {
     ): Promise<CustomerQueryResponseType>
   } = this.wrapWithRetry(this._getACustomer) as any
   getCustomerByEmail = this.wrapWithRetry(this._getCustomerByEmail)
+  getNameCollisionEntity = this.wrapWithRetry(this._getNameCollisionEntity)
   getAnItem: {
     (
       name: string,

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -68,6 +68,21 @@ export function truncateForQB(input: string, suffix?: string): string {
   return input.slice(0, maxBaseLength) + ELLIPSIS + suffix
 }
 
+const CUSTOMER_SUFFIX = ' (Customer)'
+
+/**
+ * Appends " (Customer)" to a DisplayName to disambiguate it from a colliding
+ * Vendor/Employee. QBO enforces DisplayName uniqueness across those three
+ * entities, so a Customer that shares a name with a Vendor needs a distinct
+ * name. No-op if the suffix is already present.
+ */
+export function getNameAsCustomer(name: string): string {
+  if (name.endsWith(CUSTOMER_SUFFIX)) {
+    return name
+  }
+  return `${name}${CUSTOMER_SUFFIX}`
+}
+
 export function replaceSpecialCharsForQB(input: string) {
   // list of allowed characters in QB.
   // Doc: https://quickbooks.intuit.com/learn-support/en-us/help-article/account-management/acceptable-characters-quickbooks-online/L3CiHlD9J_US_en_US


### PR DESCRIPTION
## Summary
- Fixes QB customer creation failing with error 6240 when the Copilot client's `DisplayName` collides with an existing QB Vendor or Employee (QBO enforces `DisplayName` uniqueness across all three entity types).
- Adds a pre-check via a new `IntuitAPI.getNameCollisionEntity(displayName)` that queries Vendor then Employee; if a collision is found, appends ` (Customer)` suffix to the payload `DisplayName` before calling `createCustomer`.
- Separate refactor commit removes 8 unreachable Fault-check branches that sat after `customQuery` calls (dead because `_customQuery` already throws on Fault and returns `res.QueryResponse`, which has no `Fault` field).

## Notes
- Inactive Vendors/Employees are intentionally excluded from the collision check — QBO auto-suffixes their `DisplayName` with ` (deleted)` when deactivated, freeing the original name.
- `_getNameCollisionEntity` short-circuits after finding a Vendor match (skips the Employee query).
- Mapping table's `displayName` column continues to store the Copilot-side original (not the suffixed QB name); the column's semantic is preserved and a comment now documents the intentional divergence.
- Critical-path tests were not added (no test infrastructure in this repo yet per OUT-3625 memory; separate initiative).

## Test plan
- [ ] In QB sandbox: create a Vendor named `Acme Corp`, then trigger a Copilot invoice webhook for a client whose display name resolves to `Acme Corp` → verify a Customer named `Acme Corp (Customer)` is created in QB without error 6240.
- [ ] In QB sandbox: deactivate a Vendor named `Beta Inc` (QB renames it to `Beta Inc (deleted)`), trigger webhook for a client `Beta Inc` → verify a Customer named `Beta Inc` is created (no suffix, since the inactive vendor no longer holds the name).
- [ ] Happy path regression: trigger webhook for a recipient whose display name does not collide with any Vendor/Employee → verify customer is created with the unsuffixed `DisplayName` and only 2 QB API calls were made (Vendor query + Employee query, or fewer if short-circuit).
- [ ] Verify existing `findOrCreateCustomer` behaviors unchanged (email-based short-circuit, `CompanyName` mismatch clearing).
- [ ] Refactor regression: trigger a query that would fault (e.g., invalid realm) → verify error surfaces with `IntuitAPIErrorMessage` prefix so `isIntuitError` detection in `src/utils/error.ts` still classifies it correctly.

## Testing Criteria

### handling of duplicate name across Customer, Employee and Vendor

https://www.loom.com/share/14cdacf0e4ed4918ac5b9454ac918eb5

### Case when two companies have same name

https://www.loom.com/share/11c319b68ec54fee8b7c8be75ba57581

🤖 Generated with [Claude Code](https://claude.com/claude-code)