### PR TITLE
OUT-3587: pin axios to ^1.15.2 via yarn resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
   "packageManager": "yarn@4.9.1",
   "resolutions": {
     "@types/react": "19.1.2",
-    "@types/react-dom": "19.1.2"
+    "@types/react-dom": "19.1.2",
+    "axios": "^1.15.2"
   },
   "lint-staged": {
     "src/**/*.{ts,tsx}": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -5004,14 +5004,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.9.0":
-  version: 1.14.0
-  resolution: "axios@npm:1.14.0"
+"axios@npm:^1.15.2":
+  version: 1.15.2
+  resolution: "axios@npm:1.15.2"
   dependencies:
     follow-redirects: "npm:^1.15.11"
     form-data: "npm:^4.0.5"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/2541f4aa215a7d1842429dad006fc682d82bc0e74bd14500823f7d8cce3bbae0e0a8c328c8538946718f366ab8ce5a4c12e9ad40e5a0f3482ff8bff0cd115d45
+  checksum: 10c0/4eeae0feeaa7fdc1ef24f81f8b378fdadedf4aebdd6bf224484675160f8744cf17b9b0d1c215279979940f7e8ce463beffa2f713099612e428eac238515c81d5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Resolves Dependabot alerts for axios `<1.15.0` pulled transitively through `intuit-oauth@4.2.3` (which pins axios@1.14.0).
- Affected advisories: [GHSA-3p68-rc4w-qgx5](https://github.com/advisories/GHSA-3p68-rc4w-qgx5) (NO_PROXY SSRF) and [GHSA-fvcv-3m26-pcqx](https://github.com/advisories/GHSA-fvcv-3m26-pcqx) (cloud metadata exfiltration).
- `intuit-oauth` is already at its latest version (4.2.3) with no upstream fix available. The yarn `resolutions` override is SemVer-compatible with its declared `axios: ^1.9.0` range, so no API drift.

Linear: [OUT-3587](https://linear.app/assemblycom/issue/OUT-3587/resolve-github-dependabot-alert-for-critical-axios-issues)

## Test plan
- [x] `yarn install` — axios resolves to `1.15.2` (verified via `yarn why axios`)
- [x] `yarn npm audit --all --recursive` — both advisories no longer reported
- [x] `yarn tsc --noEmit` — no new type errors introduced by the bump
- [x] Smoke test QuickBooks OAuth flow in staging (intuit-oauth is the only consumer of axios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)