### PR TITLE
OUT-3587: bump trigger.dev to 4.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "trigger:dev": "npx trigger.dev@4.3.0 dev",
+    "trigger:dev": "npx trigger.dev@4.4.4 dev",
+    "trigger:deploy": "npx trigger.dev@4.4.4 deploy",
     "dev:embedded": "node scripts/dev.js",
     "build": "next build",
     "start": "next start",
@@ -28,7 +29,7 @@
   "dependencies": {
     "@sentry/nextjs": "^9.13.0",
     "@supabase/supabase-js": "^2.49.4",
-    "@trigger.dev/sdk": "4.3.0",
+    "@trigger.dev/sdk": "4.4.4",
     "bottleneck": "^2.19.5",
     "copilot-design-system": "^2.0.10",
     "copilot-node-sdk": "~3.16.0",
@@ -62,7 +63,7 @@
     "@ngrok/ngrok": "^1.4.1",
     "@sentry/esbuild-plugin": "^4.6.1",
     "@tailwindcss/postcss": "^4.1.5",
-    "@trigger.dev/build": "4.3.0",
+    "@trigger.dev/build": "4.4.4",
     "@types/deep-equal": "^1.0.4",
     "@types/html-to-text": "^9",
     "@types/node": "^22.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2071,6 +2071,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/exporter-metrics-otlp-http@npm:0.203.0":
+  version: 0.203.0
+  resolution: "@opentelemetry/exporter-metrics-otlp-http@npm:0.203.0"
+  dependencies:
+    "@opentelemetry/core": "npm:2.0.1"
+    "@opentelemetry/otlp-exporter-base": "npm:0.203.0"
+    "@opentelemetry/otlp-transformer": "npm:0.203.0"
+    "@opentelemetry/resources": "npm:2.0.1"
+    "@opentelemetry/sdk-metrics": "npm:2.0.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/6fd10835fa998023095b57f74d550f976fe3396cfdc1004fb6f678bd9fadc86d58f428d0c0f8618d1a96f20f3fbb8c6e6e4862e4833b22bcf70dc0b7920cb049
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/exporter-trace-otlp-http@npm:0.203.0":
   version: 0.203.0
   resolution: "@opentelemetry/exporter-trace-otlp-http@npm:0.203.0"
@@ -2083,6 +2098,17 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
   checksum: 10c0/21a65ebc40dcab05cf11178e5037f96847ce344c4a855aac46dcab3f74982016318ee75fafdfeeb42f10b92a0a781b7cd8b2b5b036cbe53c14714fd13940142e
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/host-metrics@npm:^0.37.0":
+  version: 0.37.0
+  resolution: "@opentelemetry/host-metrics@npm:0.37.0"
+  dependencies:
+    systeminformation: "npm:5.23.8"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/aec7695c7f891c007d4ea586f448001aa90a98e31450ae6acf2388f5b4e1aff25de7ca49f4dcf13858a534da38ae0860ec1486261207ed23c8a99df8a11c0fdc
   languageName: node
   linkType: hard
 
@@ -3311,14 +3337,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@s2-dev/streamstore@npm:0.17.3":
-  version: 0.17.3
-  resolution: "@s2-dev/streamstore@npm:0.17.3"
+"@s2-dev/streamstore@npm:0.22.5":
+  version: 0.22.5
+  resolution: "@s2-dev/streamstore@npm:0.22.5"
   dependencies:
     "@protobuf-ts/runtime": "npm:^2.11.1"
-  peerDependencies:
-    typescript: ^5.9.3
-  checksum: 10c0/38fc483711a32a3fe6474c7df400d84299a4f41ec2eb8800ab56c36702774489dadf2531cbc09dbe4b2068af0d5b310b6d11fada4d9b88b0cdd9fc2d1bcd112c
+    debug: "npm:^4.4.3"
+  checksum: 10c0/bcd9e87edaad61ba9a9ec54a2c48f3041d597ae4d8069ba4c8ed3d047e71d9269e68db171ca472559223304238db34e949f9e34244fc141405c7a8cbe7954420
   languageName: node
   linkType: hard
 
@@ -4011,24 +4036,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@trigger.dev/build@npm:4.3.0":
-  version: 4.3.0
-  resolution: "@trigger.dev/build@npm:4.3.0"
+"@trigger.dev/build@npm:4.4.4":
+  version: 4.4.4
+  resolution: "@trigger.dev/build@npm:4.4.4"
   dependencies:
     "@prisma/config": "npm:^6.10.0"
-    "@trigger.dev/core": "npm:4.3.0"
+    "@trigger.dev/core": "npm:4.4.4"
     mlly: "npm:^1.7.1"
     pkg-types: "npm:^1.1.3"
     resolve: "npm:^1.22.8"
     tinyglobby: "npm:^0.2.2"
     tsconfck: "npm:3.1.3"
-  checksum: 10c0/5b16987bc19ec8d7bf79a81280be5d285e538d82dac77f4fa03571795a5e6d0333d96c6ca9860cc1a0666692b90d345605b08223bc0e9e92b234a6f856329ac7
+  checksum: 10c0/b0bb5836207c3a6c62844c341fa2c2d93e6ba4c4fe90406442f3c83e636df29965c7afe59b568730c10a46c59dd81346b9a7d7dfc18f35bb8afb608b82ec4604
   languageName: node
   linkType: hard
 
-"@trigger.dev/core@npm:4.3.0":
-  version: 4.3.0
-  resolution: "@trigger.dev/core@npm:4.3.0"
+"@trigger.dev/core@npm:4.4.4":
+  version: 4.4.4
+  resolution: "@trigger.dev/core@npm:4.4.4"
   dependencies:
     "@bugsnag/cuid": "npm:^3.1.1"
     "@electric-sql/client": "npm:1.0.14"
@@ -4038,14 +4063,17 @@ __metadata:
     "@opentelemetry/api-logs": "npm:0.203.0"
     "@opentelemetry/core": "npm:2.0.1"
     "@opentelemetry/exporter-logs-otlp-http": "npm:0.203.0"
+    "@opentelemetry/exporter-metrics-otlp-http": "npm:0.203.0"
     "@opentelemetry/exporter-trace-otlp-http": "npm:0.203.0"
+    "@opentelemetry/host-metrics": "npm:^0.37.0"
     "@opentelemetry/instrumentation": "npm:0.203.0"
     "@opentelemetry/resources": "npm:2.0.1"
     "@opentelemetry/sdk-logs": "npm:0.203.0"
+    "@opentelemetry/sdk-metrics": "npm:2.0.1"
     "@opentelemetry/sdk-trace-base": "npm:2.0.1"
     "@opentelemetry/sdk-trace-node": "npm:2.0.1"
     "@opentelemetry/semantic-conventions": "npm:1.36.0"
-    "@s2-dev/streamstore": "npm:0.17.3"
+    "@s2-dev/streamstore": "npm:0.22.5"
     dequal: "npm:^2.0.3"
     eventsource: "npm:^3.0.5"
     eventsource-parser: "npm:^3.0.0"
@@ -4057,23 +4085,22 @@ __metadata:
     socket.io: "npm:4.7.4"
     socket.io-client: "npm:4.7.5"
     std-env: "npm:^3.8.1"
-    superjson: "npm:^2.2.1"
     tinyexec: "npm:^0.3.2"
     uncrypto: "npm:^0.1.3"
     zod: "npm:3.25.76"
     zod-error: "npm:1.5.0"
     zod-validation-error: "npm:^1.5.0"
-  checksum: 10c0/84d2d06fff4258e5b3148a81435a4a877226db1a493aef1436ee81a879c7b8be897bec46914e1739f709011e9165ab4298ba56feecf508e780e6ec3c78dc2e13
+  checksum: 10c0/053844894dba5a0125ce47a958c650184f3a4088f4444a0d58e3da80b4baab9d797a248e8f86f2fcb81b41c58f84188fcdba2b37b0333b69e805df3da3a23551
   languageName: node
   linkType: hard
 
-"@trigger.dev/sdk@npm:4.3.0":
-  version: 4.3.0
-  resolution: "@trigger.dev/sdk@npm:4.3.0"
+"@trigger.dev/sdk@npm:4.4.4":
+  version: 4.4.4
+  resolution: "@trigger.dev/sdk@npm:4.4.4"
   dependencies:
     "@opentelemetry/api": "npm:1.9.0"
     "@opentelemetry/semantic-conventions": "npm:1.36.0"
-    "@trigger.dev/core": "npm:4.3.0"
+    "@trigger.dev/core": "npm:4.4.4"
     chalk: "npm:^5.2.0"
     cronstrue: "npm:^2.21.0"
     debug: "npm:^4.3.4"
@@ -4084,12 +4111,12 @@ __metadata:
     uuid: "npm:^9.0.0"
     ws: "npm:^8.11.0"
   peerDependencies:
-    ai: ^4.2.0 || ^5.0.0
+    ai: ^4.2.0 || ^5.0.0 || ^6.0.0
     zod: ^3.0.0 || ^4.0.0
   peerDependenciesMeta:
     ai:
       optional: true
-  checksum: 10c0/73427e95f3f64bb4824e8d7caa32c23b28f4107f1dd8eda43b3d4eb9307cdbe20e6c3fa3742c2bc4f1c7e21133d4f0715e08a787cdc2566415f728cb133006a8
+  checksum: 10c0/fd9b425db4e0d8c26bf6e75bcf7d17a173a218cd6f2ff6337f768373e70b9666b8dc1eac5cea68aaeb99c3af86252a5d16a413b3525f168ce1509725b57f2fd4
   languageName: node
   linkType: hard
 
@@ -5639,15 +5666,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"copy-anything@npm:^4":
-  version: 4.0.5
-  resolution: "copy-anything@npm:4.0.5"
-  dependencies:
-    is-what: "npm:^5.2.0"
-  checksum: 10c0/d0a4a4102334399dae8504a2c2e13f45ad05746a9fd5cc0df349a554e3749a05e8a6d62b3724a8049cd59fc0bbbf4f54c4edc94a428edc76211dffe3ac0af586
-  languageName: node
-  linkType: hard
-
 "cors@npm:~2.8.5":
   version: 2.8.6
   resolution: "cors@npm:2.8.6"
@@ -5749,8 +5767,8 @@ __metadata:
     "@sentry/nextjs": "npm:^9.13.0"
     "@supabase/supabase-js": "npm:^2.49.4"
     "@tailwindcss/postcss": "npm:^4.1.5"
-    "@trigger.dev/build": "npm:4.3.0"
-    "@trigger.dev/sdk": "npm:4.3.0"
+    "@trigger.dev/build": "npm:4.4.4"
+    "@trigger.dev/sdk": "npm:4.4.4"
     "@types/deep-equal": "npm:^1.0.4"
     "@types/html-to-text": "npm:^9"
     "@types/node": "npm:^22.14.1"
@@ -5933,6 +5951,18 @@ __metadata:
     supports-color:
       optional: true
   checksum: 10c0/db94f1a182bf886f57b4755f85b3a74c39b5114b9377b7ab375dc2cfa3454f09490cc6c30f829df3fc8042bc8b8995f6567ce5cd96f3bc3688bd24027197d9de
+  languageName: node
+  linkType: hard
+
+"debug@npm:^4.4.3":
+  version: 4.4.3
+  resolution: "debug@npm:4.4.3"
+  dependencies:
+    ms: "npm:^2.1.3"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 10c0/d79136ec6c83ecbefd0f6a5593da6a9c91ec4d7ddc4b54c883d6e71ec9accb5f67a1a5e96d00a328196b5b5c86d365e98d8a3a70856aaf16b4e7b1985e67f5a6
   languageName: node
   linkType: hard
 
@@ -8885,13 +8915,6 @@ __metadata:
     call-bind: "npm:^1.0.7"
     get-intrinsic: "npm:^1.2.4"
   checksum: 10c0/8ad6141b6a400e7ce7c7442a13928c676d07b1f315ab77d9912920bf5f4170622f43126f111615788f26c3b1871158a6797c862233124507db0bcc33a9537d1a
-  languageName: node
-  linkType: hard
-
-"is-what@npm:^5.2.0":
-  version: 5.5.0
-  resolution: "is-what@npm:5.5.0"
-  checksum: 10c0/065c8a4ac651988a495cc0211c2754c198788383c9fe1bbfdf6d237c423114a0c5f2fc3e26ad7ea43a63cd4169f4503f584305acbac91706d5308cc14dedd1bd
   languageName: node
   linkType: hard
 
@@ -12594,15 +12617,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"superjson@npm:^2.2.1":
-  version: 2.2.6
-  resolution: "superjson@npm:2.2.6"
-  dependencies:
-    copy-anything: "npm:^4"
-  checksum: 10c0/b63587656cc27effd12c9e13a66da673a7a1b3e1af41f17820fd37f07a4f29503e1f58eae6bd229039331b475e1be6990336fa887654e6adc80684ae4eed7965
-  languageName: node
-  linkType: hard
-
 "supports-color@npm:^7.1.0":
   version: 7.2.0
   resolution: "supports-color@npm:7.2.0"
@@ -12638,6 +12652,16 @@ __metadata:
     "@pkgr/core": "npm:^0.2.3"
     tslib: "npm:^2.8.1"
   checksum: 10c0/dd2965a37c93c0b652bf07b1fd8d1639a803b65cf34c0cb1b827b8403044fc3b09ec87f681d922a324825127ee95b2e0394e7caccb502f407892d63e903c5276
+  languageName: node
+  linkType: hard
+
+"systeminformation@npm:5.23.8":
+  version: 5.23.8
+  resolution: "systeminformation@npm:5.23.8"
+  bin:
+    systeminformation: lib/cli.js
+  checksum: 10c0/d4d750d82345081a6a12200ec8f559ff65a8c28d9797d4368c246682ee02131ee08a4227e4401b6680839f0f0e1a72758071fd84eae2f0584a89e948d583703f
+  conditions: (os=darwin | os=linux | os=win32 | os=freebsd | os=openbsd | os=netbsd | os=sunos | os=android)
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Upgrade @trigger.dev/sdk and @trigger.dev/build from 4.3.0 to 4.4.4 to match the CLI version used in trigger:dev/trigger:deploy scripts. Pin exact versions (no caret) to keep the SDK, build extension, and CLI in lockstep and avoid silent minor drift on future yarn upgrades.

Also adds trigger:deploy script for operational convenience.

