### PR TITLE
OUT-3644: add idempotency guards on qb_invoice_sync writes

### DIFF
--- a/src/app/api/quickbooks/invoice/invoice.service.ts
+++ b/src/app/api/quickbooks/invoice/invoice.service.ts
@@ -785,7 +785,20 @@ export class InvoiceService extends BaseService {
       customerId: existingCustomerMapId, // foreign key to customer mapping
       status: invoiceResource.status,
     }
-    await this.createQBInvoice(invoicePayload)
+    const inserted = await this.createQBInvoice(invoicePayload, ['id'])
+
+    // If onConflictDoNothing skipped the insert, a concurrent delivery won
+    // the race. Skip logSync (the winner already wrote the CREATED log;
+    // overwriting it would point quickbooks_id at this losing webhook's
+    // orphaned QBO invoice) and skip the paid-path payment creation.
+    // Note: the duplicate QBO invoice from createInvoice above is the
+    // dual-create issue tracked separately in OUT-3655.
+    if (!inserted) {
+      console.info(
+        'InvoiceService#webhookInvoiceCreated | Mapping already exists (race loss), skipping logSync and payment',
+      )
+      return
+    }
 
     // update/ create the record in sync log table
     const totalWithTax = actualTotalAmount + totalTax

--- a/src/app/api/quickbooks/invoice/invoice.service.ts
+++ b/src/app/api/quickbooks/invoice/invoice.service.ts
@@ -78,7 +78,17 @@ export class InvoiceService extends BaseService {
     returningFields?: (keyof typeof QBInvoiceSync)[],
   ) {
     const parsedInsertPayload = QBInvoiceCreateSchema.parse(payload)
-    const query = this.db.insert(QBInvoiceSync).values(parsedInsertPayload)
+    // Concurrent webhook deliveries for the same invoice can race past the
+    // app-level existence checks; the partial unique index on
+    // (portal_id, invoice_number) WHERE deleted_at IS NULL is the durable
+    // guard. Swallow conflicts here so the loser of the race no-ops.
+    const query = this.db
+      .insert(QBInvoiceSync)
+      .values(parsedInsertPayload)
+      .onConflictDoNothing({
+        target: [QBInvoiceSync.portalId, QBInvoiceSync.invoiceNumber],
+        where: isNull(QBInvoiceSync.deletedAt),
+      })
 
     const [invoiceSync] = returningFields?.length
       ? await query.returning(
@@ -1337,6 +1347,18 @@ export class InvoiceService extends BaseService {
       return null
     }
 
+    // 2. Re-check the local mapping. A concurrent webhook delivery may have
+    // inserted the row while we were fetching from QBO; short-circuit to
+    // avoid wasted customer/mapping work. The partial unique index closes
+    // the remaining window between this check and the INSERT below.
+    const alreadyMapped = await this.getInvoiceByNumber(invoiceNumber)
+    if (alreadyMapped) {
+      console.info(
+        'InvoiceService#findOrMapInvoiceFromQBO | Mapping already exists, skipping',
+      )
+      return alreadyMapped
+    }
+
     // 3. Resolve customer mapping (reuse existing pattern from webhookInvoiceCreated)
     const customerService = new CustomerService(this.user)
     const { recipientInfo, companyInfo } =
@@ -1369,15 +1391,25 @@ export class InvoiceService extends BaseService {
     }
 
     // 4. Create the qb_invoice_sync mapping row
-    await this.createQBInvoice({
-      portalId: this.user.workspaceId,
-      invoiceNumber,
-      qbInvoiceId: qbInvoice.Id,
-      qbSyncToken: qbInvoice.SyncToken,
-      recipientId: recipientInfo.recipientId,
-      customerId: customerMapId,
-      status,
-    })
+    const inserted = await this.createQBInvoice(
+      {
+        portalId: this.user.workspaceId,
+        invoiceNumber,
+        qbInvoiceId: qbInvoice.Id,
+        qbSyncToken: qbInvoice.SyncToken,
+        recipientId: recipientInfo.recipientId,
+        customerId: customerMapId,
+        status,
+      },
+      ['id'],
+    )
+
+    // If onConflictDoNothing skipped the insert, a concurrent delivery won
+    // the race. Skip re-logging (the winner already wrote the sync log) and
+    // return the existing mapping.
+    if (!inserted) {
+      return await this.getInvoiceByNumber(invoiceNumber)
+    }
 
     // 5. Create the sync log entry
     await this.logSync(

--- a/src/app/api/quickbooks/syncLog/syncLog.service.ts
+++ b/src/app/api/quickbooks/syncLog/syncLog.service.ts
@@ -76,11 +76,14 @@ export class SyncLogService extends BaseService {
     eventType: EventType
     entityType: EntityType
   }) {
+    // Excludes soft-deleted rows so updateOrCreateQBSyncLog can't accidentally
+    // revive a previously soft-deleted log by updating it in place.
     const conditions = [
       eq(QBSyncLog.portalId, this.user.workspaceId),
       eq(QBSyncLog.copilotId, copilotId),
       eq(QBSyncLog.eventType, eventType),
       eq(QBSyncLog.entityType, entityType),
+      isNull(QBSyncLog.deletedAt),
     ]
 
     const query = this.db.query.QBSyncLog.findFirst({
@@ -107,9 +110,12 @@ export class SyncLogService extends BaseService {
     let existingLog
 
     if (conditions) {
+      // Exclude soft-deleted rows so a previously soft-deleted log isn't
+      // revived by an in-place update.
       const sqlConditions = and(
         ...[conditions],
         eq(QBSyncLog.entityType, payload.entityType),
+        isNull(QBSyncLog.deletedAt),
       ) as WhereClause
       existingLog = await this.getOne(sqlConditions)
     } else {

--- a/src/db/migrations/20260427055352_add_unique_index_with_portal_id_and_invoice_number_in_qb_invoice_sync.sql
+++ b/src/db/migrations/20260427055352_add_unique_index_with_portal_id_and_invoice_number_in_qb_invoice_sync.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX "uq_qb_invoice_sync_portal_id_invoice_number_active_idx" ON "qb_invoice_sync" USING btree ("portal_id","invoice_number") WHERE "qb_invoice_sync"."deleted_at" is null;

--- a/src/db/migrations/meta/20260427055352_snapshot.json
+++ b/src/db/migrations/meta/20260427055352_snapshot.json
@@ -1,0 +1,1009 @@
+{
+  "id": "911cb534-9808-40fa-840f-e90da62522d0",
+  "prevId": "1c9fbc27-72b3-4a6e-860c-6e3f247135d5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.qb_connection_logs": {
+      "name": "qb_connection_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_status": {
+          "name": "connection_status",
+          "type": "connection_statuses",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qb_customers": {
+      "name": "qb_customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_company_id": {
+          "name": "client_company_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "given_name": {
+          "name": "given_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "family_name": {
+          "name": "family_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_type": {
+          "name": "customer_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'client'"
+        },
+        "qb_sync_token": {
+          "name": "qb_sync_token",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qb_customer_id": {
+          "name": "qb_customer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_qb_customers_client_company_id_type_active_idx": {
+          "name": "uq_qb_customers_client_company_id_type_active_idx",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "customer_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"qb_customers\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qb_invoice_sync": {
+      "name": "qb_invoice_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qb_invoice_id": {
+          "name": "qb_invoice_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qb_sync_token": {
+          "name": "qb_sync_token",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_statuses",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_qb_invoice_sync_portal_id_invoice_number_active_idx": {
+          "name": "uq_qb_invoice_sync_portal_id_invoice_number_active_idx",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invoice_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"qb_invoice_sync\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "qb_invoice_sync_customer_id_qb_customers_id_fk": {
+          "name": "qb_invoice_sync_customer_id_qb_customers_id_fk",
+          "tableFrom": "qb_invoice_sync",
+          "tableTo": "qb_customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qb_payment_sync": {
+      "name": "qb_payment_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qb_payment_id": {
+          "name": "qb_payment_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qb_sync_token": {
+          "name": "qb_sync_token",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qb_portal_connections": {
+      "name": "qb_portal_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intuit_realm_id": {
+          "name": "intuit_realm_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_in": {
+          "name": "expires_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x_refresh_token_expires_in": {
+          "name": "x_refresh_token_expires_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_set_time": {
+          "name": "token_set_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intiated_by": {
+          "name": "intiated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "income_account_ref": {
+          "name": "income_account_ref",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_account_ref": {
+          "name": "asset_account_ref",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expense_account_ref": {
+          "name": "expense_account_ref",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_fee_ref": {
+          "name": "client_fee_ref",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_item_ref": {
+          "name": "service_item_ref",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_suspended": {
+          "name": "is_suspended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_qb_portal_connections_portal_id_idx": {
+          "name": "uq_qb_portal_connections_portal_id_idx",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qb_product_sync": {
+      "name": "qb_product_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "copilot_name": {
+          "name": "copilot_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "copilot_unit_price": {
+          "name": "copilot_unit_price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qb_item_id": {
+          "name": "qb_item_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qb_sync_token": {
+          "name": "qb_sync_token",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_excluded": {
+          "name": "is_excluded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qb_settings": {
+      "name": "qb_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "absorbed_fee_flag": {
+          "name": "absorbed_fee_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "company_name_flag": {
+          "name": "company_name_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "create_new_product_flag": {
+          "name": "create_new_product_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "initial_invoice_setting_map": {
+          "name": "initial_invoice_setting_map",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "initial_product_setting_map": {
+          "name": "initial_product_setting_map",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sync_flag": {
+          "name": "sync_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "qb_settings_portal_id_qb_portal_connections_portal_id_fk": {
+          "name": "qb_settings_portal_id_qb_portal_connections_portal_id_fk",
+          "tableFrom": "qb_settings",
+          "tableTo": "qb_portal_connections",
+          "columnsFrom": [
+            "portal_id"
+          ],
+          "columnsTo": [
+            "portal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.qb_sync_logs": {
+      "name": "qb_sync_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "entity_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invoice'"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "event_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "status": {
+          "name": "status",
+          "type": "log_statuses",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'success'"
+        },
+        "sync_at": {
+          "name": "sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "copilot_id": {
+          "name": "copilot_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quickbooks_id": {
+          "name": "quickbooks_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remark": {
+          "name": "remark",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_email": {
+          "name": "customer_email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_amount": {
+          "name": "fee_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_price": {
+          "name": "product_price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qb_item_name": {
+          "name": "qb_item_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "copilot_price_id": {
+          "name": "copilot_price_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "failed_record_category_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'others'"
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.connection_statuses": {
+      "name": "connection_statuses",
+      "schema": "public",
+      "values": [
+        "pending",
+        "success",
+        "error"
+      ]
+    },
+    "public.invoice_statuses": {
+      "name": "invoice_statuses",
+      "schema": "public",
+      "values": [
+        "draft",
+        "open",
+        "paid",
+        "void",
+        "deleted"
+      ]
+    },
+    "public.entity_types": {
+      "name": "entity_types",
+      "schema": "public",
+      "values": [
+        "invoice",
+        "product",
+        "payment"
+      ]
+    },
+    "public.event_types": {
+      "name": "event_types",
+      "schema": "public",
+      "values": [
+        "created",
+        "updated",
+        "paid",
+        "voided",
+        "deleted",
+        "succeeded",
+        "mapped",
+        "unmapped"
+      ]
+    },
+    "public.failed_record_category_types": {
+      "name": "failed_record_category_types",
+      "schema": "public",
+      "values": [
+        "auth",
+        "account",
+        "rate_limit",
+        "validation",
+        "qb_api_error",
+        "mapping_not_found",
+        "others"
+      ]
+    },
+    "public.log_statuses": {
+      "name": "log_statuses",
+      "schema": "public",
+      "values": [
+        "success",
+        "failed",
+        "info"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1776326817946,
       "tag": "20260416080657_update_service_name_length_constraint",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1777269232971,
+      "tag": "20260427055352_add_unique_index_with_portal_id_and_invoice_number_in_qb_invoice_sync",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/qbInvoiceSync.ts
+++ b/src/db/schema/qbInvoiceSync.ts
@@ -2,7 +2,7 @@ import { InvoiceStatus } from '@/app/api/core/types/invoice'
 import { timestamps } from '@/db/helper/column.helper'
 import { enumToPgEnum } from '@/db/helper/drizzle.helper'
 import { QBCustomers } from '@/db/schema/qbCustomers'
-import { relations } from 'drizzle-orm'
+import { isNull, relations } from 'drizzle-orm'
 import { pgTable as table } from 'drizzle-orm/pg-core'
 import * as t from 'drizzle-orm/pg-core'
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod'
@@ -13,20 +13,29 @@ export const invoiceStatusEnum = t.pgEnum(
   enumToPgEnum(InvoiceStatus),
 )
 
-export const QBInvoiceSync = table('qb_invoice_sync', {
-  id: t.uuid().defaultRandom().primaryKey(),
-  portalId: t.varchar('portal_id', { length: 255 }).notNull(),
-  customerId: t.uuid('customer_id').references(() => QBCustomers.id, {
-    onDelete: 'cascade',
-    onUpdate: 'cascade',
-  }),
-  invoiceNumber: t.varchar('invoice_number').notNull(),
-  qbInvoiceId: t.varchar('qb_invoice_id'),
-  qbSyncToken: t.varchar('qb_sync_token', { length: 100 }),
-  recipientId: t.uuid('recipient_id'),
-  status: invoiceStatusEnum('status').default(InvoiceStatus.OPEN).notNull(),
-  ...timestamps,
-})
+export const QBInvoiceSync = table(
+  'qb_invoice_sync',
+  {
+    id: t.uuid().defaultRandom().primaryKey(),
+    portalId: t.varchar('portal_id', { length: 255 }).notNull(),
+    customerId: t.uuid('customer_id').references(() => QBCustomers.id, {
+      onDelete: 'cascade',
+      onUpdate: 'cascade',
+    }),
+    invoiceNumber: t.varchar('invoice_number').notNull(),
+    qbInvoiceId: t.varchar('qb_invoice_id'),
+    qbSyncToken: t.varchar('qb_sync_token', { length: 100 }),
+    recipientId: t.uuid('recipient_id'),
+    status: invoiceStatusEnum('status').default(InvoiceStatus.OPEN).notNull(),
+    ...timestamps,
+  },
+  (table) => [
+    t
+      .uniqueIndex('uq_qb_invoice_sync_portal_id_invoice_number_active_idx')
+      .on(table.portalId, table.invoiceNumber)
+      .where(isNull(table.deletedAt)),
+  ],
+)
 
 export const QBInvoiceSyncRelations = relations(QBInvoiceSync, ({ one }) => ({
   customer: one(QBCustomers, {


### PR DESCRIPTION
## Summary

- Partial unique index on `qb_invoice_sync (portal_id, invoice_number) WHERE deleted_at IS NULL` + `onConflictDoNothing` in `createQBInvoice` — concurrent webhook deliveries can no longer insert duplicate mapping rows.
- Inline re-check guard in `findOrMapInvoiceFromQBO` after the QBO fetch; race-loss path skips redundant `logSync`.
- `getOneByCopilotIdAndEventType` and the conditions branch of `updateOrCreateQBSyncLog` now filter `isNull(deletedAt)` so soft-deleted log rows can't be revived in-place.

`qb_sync_logs` unique index was descoped — production has too many historical duplicates to add the constraint cleanly. Webhook-entry idempotency tracked in [OUT-3655](https://linear.app/assemblycom/issue/OUT-3655).

Linear: https://linear.app/assemblycom/issue/OUT-3644

## Test plan

- [ ] Apply migration in dev, confirm partial unique index exists on `qb_invoice_sync`
- [ ] Replay two `invoice.created` webhooks in parallel for the same invoice — verify only one `qb_invoice_sync` row, only one `qb_sync_logs` CREATED row
- [ ] Soft-delete a `qb_sync_logs` row, then trigger a sync that would normally update it — verify a new row is created instead of reviving the soft-deleted one
- [ ] Existing sync flows (create / paid / voided / deleted) regress-test against QBO sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)