### PR TITLE
OUT-3545: parallelize home render and batch Copilot price fetch

### DIFF
--- a/src/action/quickbooks.action.ts
+++ b/src/action/quickbooks.action.ts
@@ -2,11 +2,7 @@
 
 import { AuthStatus } from '@/app/api/core/types/auth'
 import { PortalConnectionWithSettingType } from '@/db/schema/qbPortalConnections'
-import { QBSettingsSelectSchemaType } from '@/db/schema/qbSettings'
-import {
-  getPortalConnection,
-  getPortalSettings,
-} from '@/db/service/token.service'
+import { getPortalConnection } from '@/db/service/token.service'
 import IntuitAPI from '@/utils/intuitAPI'
 import CustomLogger from '@/utils/logger'
 import {
@@ -23,17 +19,6 @@ export async function checkPortalConnection(
   } catch (err) {
     console.error('checkPortalConnection#getPortalConnection | Error =', err)
     return null
-  }
-}
-
-export async function checkSyncStatus(portalId: string): Promise<boolean> {
-  try {
-    const syncedPortal: QBSettingsSelectSchemaType | null =
-      await getPortalSettings(portalId)
-    return syncedPortal?.syncFlag || false
-  } catch (err) {
-    console.error('checkSyncStatus#getPortalSettings | Error =', err)
-    return false
   }
 }
 

--- a/src/app/(home)/Home.tsx
+++ b/src/app/(home)/Home.tsx
@@ -1,22 +1,15 @@
 import { getTokenPayload } from '@/action/copilot.action'
 import {
   checkPortalConnection,
-  checkSyncStatus,
   reconnectIfCta,
 } from '@/action/quickbooks.action'
 import HomeClient from '@/app/(home)/HomeClient'
+import User from '@/app/api/core/models/User.model'
+import { SyncLogService } from '@/app/api/quickbooks/syncLog/syncLog.service'
 import { AppProvider } from '@/app/context/AppContext'
 import { SilentError } from '@/components/template/SilentError'
-import { apiUrl } from '@/config'
 import { getWorkspaceInfo } from '@/db/service/token.service'
 import { z } from 'zod'
-
-export async function getLatestSuccesLog(token: string) {
-  const response = await fetch(
-    `${apiUrl}/api/quickbooks/syncLog/success?token=${token}`,
-  )
-  return (await response.json()).data
-}
 
 export default async function Main({
   searchParams,
@@ -44,39 +37,38 @@ export default async function Main({
     return <SilentError message="No access to the user" />
   }
 
-  const portalConnection = await checkPortalConnection(tokenPayload.workspaceId)
-  const portalConnectionStatus =
-    portalConnection && Object.keys(portalConnection).length > 0 ? true : false
+  const syncLogService = new SyncLogService(new User(token, tokenPayload))
 
-  let reconnect = false,
-    syncFlag = false,
-    successLog = null,
-    isEnabled = false
-  if (portalConnectionStatus) {
-    syncFlag = await checkSyncStatus(tokenPayload.workspaceId)
-    isEnabled = portalConnection?.setting?.isEnabled || false
+  const [portalConnection, workspace, latestSuccessLog] = await Promise.all([
+    checkPortalConnection(tokenPayload.workspaceId),
+    getWorkspaceInfo(token),
+    syncLogService.getLatestSyncSuccessLog(),
+  ])
 
-    if (!syncFlag) {
-      reconnect = await reconnectIfCta(type)
-    } else {
-      successLog = await getLatestSuccesLog(token)
-    }
-  }
+  const portalConnectionStatus = !!(
+    portalConnection && Object.keys(portalConnection).length
+  )
+  const syncFlag = portalConnection?.setting?.syncFlag ?? false
+  const isEnabled = portalConnection?.setting?.isEnabled ?? false
+  const reconnect =
+    portalConnectionStatus && !syncFlag ? await reconnectIfCta(type) : false
+  const lastSyncTimestamp =
+    portalConnectionStatus && syncFlag
+      ? (latestSuccessLog?.updatedAt?.toISOString() ?? null)
+      : null
 
   return (
-    <>
-      <AppProvider
-        token={token}
-        tokenPayload={tokenPayload}
-        syncFlag={syncFlag}
-        reconnect={reconnect}
-        portalConnectionStatus={portalConnectionStatus}
-        isEnabled={isEnabled}
-        lastSyncTimestamp={successLog?.updatedAt || null}
-        workspace={await getWorkspaceInfo(token)}
-      >
-        <HomeClient />
-      </AppProvider>
-    </>
+    <AppProvider
+      token={token}
+      tokenPayload={tokenPayload}
+      syncFlag={syncFlag}
+      reconnect={reconnect}
+      portalConnectionStatus={portalConnectionStatus}
+      isEnabled={isEnabled}
+      lastSyncTimestamp={lastSyncTimestamp}
+      workspace={workspace}
+    >
+      <HomeClient />
+    </AppProvider>
   )
 }

--- a/src/app/(home)/Home.tsx
+++ b/src/app/(home)/Home.tsx
@@ -42,7 +42,10 @@ export default async function Main({
   const [portalConnection, workspace, latestSuccessLog] = await Promise.all([
     checkPortalConnection(tokenPayload.workspaceId),
     getWorkspaceInfo(token),
-    syncLogService.getLatestSyncSuccessLog(),
+    syncLogService.getLatestSyncSuccessLog().catch((err) => {
+      console.error('Home#getLatestSyncSuccessLog | Error =', err)
+      return null
+    }),
   ])
 
   const portalConnectionStatus = !!(

--- a/src/app/(home)/loading.tsx
+++ b/src/app/(home)/loading.tsx
@@ -1,0 +1,9 @@
+import { Spinner } from 'copilot-design-system'
+
+export default function Loading() {
+  return (
+    <div className="loading-spinner h-screen flex items-center justify-center">
+      <Spinner size={10} />
+    </div>
+  )
+}

--- a/src/app/api/quickbooks/product/flatten/route.ts
+++ b/src/app/api/quickbooks/product/flatten/route.ts
@@ -1,6 +1,6 @@
 import { withErrorHandler } from '@/app/api/core/utils/withErrorHandler'
-import { getFlattenProducts } from '@/app/api/quickbooks/product/product.controller'
+import { getProductsWithPrices } from '@/app/api/quickbooks/product/product.controller'
 
 export const maxDuration = 300 // 5 minutes
 
-export const GET = withErrorHandler(getFlattenProducts)
+export const GET = withErrorHandler(getProductsWithPrices)

--- a/src/app/api/quickbooks/product/product.controller.ts
+++ b/src/app/api/quickbooks/product/product.controller.ts
@@ -5,10 +5,10 @@ import { ProductService } from '@/app/api/quickbooks/product/product.service'
 import { ProductMappingSchema } from '@/db/schema/qbProductSync'
 import { NextRequest, NextResponse } from 'next/server'
 
-export async function getFlattenProducts(req: NextRequest) {
+export async function getProductsWithPrices(req: NextRequest) {
   const user = await authenticate(req)
   const productService = new ProductService(user)
-  const products = await productService.getFlattenProductList()
+  const products = await productService.getProductsWithPrices()
   return NextResponse.json(products)
 }
 

--- a/src/app/api/quickbooks/product/product.controller.ts
+++ b/src/app/api/quickbooks/product/product.controller.ts
@@ -8,10 +8,7 @@ import { NextRequest, NextResponse } from 'next/server'
 export async function getFlattenProducts(req: NextRequest) {
   const user = await authenticate(req)
   const productService = new ProductService(user)
-  const searchParams = req.nextUrl.searchParams
-  const nextToken = searchParams.get('nextToken') || undefined
-  const limit = Number(searchParams.get('limit')) || MAX_PRODUCT_LIST_LIMIT
-  const products = await productService.getFlattenProductList(limit, nextToken)
+  const products = await productService.getFlattenProductList()
   return NextResponse.json(products)
 }
 

--- a/src/app/api/quickbooks/product/product.service.ts
+++ b/src/app/api/quickbooks/product/product.service.ts
@@ -12,9 +12,8 @@ import {
   ProductChangedItemReferenceType,
   ProductMappingSchemaType,
 } from '@/db/schema/qbProductSync'
-import { ProductResponse, WhereClause } from '@/type/common'
+import { PriceResponse, WhereClause } from '@/type/common'
 import { ProductFlattenArrayResponseType } from '@/type/dto/api.dto'
-import { bottleneck } from '@/utils/bottleneck'
 import { QBItemFullUpdatePayloadType } from '@/type/dto/intuitAPI.dto'
 import {
   PriceCreatedResponseType,
@@ -41,6 +40,7 @@ import {
 } from '@/utils/string'
 import { AccountTypeObj } from '@/constant/qbConnection'
 import { TokenService } from '@/app/api/quickbooks/token/token.service'
+import { MAX_PRODUCT_LIST_LIMIT } from '@/app/api/core/constants/limit'
 
 export type ProductSyncTokenResponse = {
   id: string
@@ -319,47 +319,68 @@ export class ProductService extends BaseService {
     return await intuitApi.createItem(qbItemPayload)
   }
 
-  async getFlatMapforAProduct(product: ProductResponse, copilot: CopilotAPI) {
-    const prices = await copilot.getPrices(product.id)
-    return (prices?.data ?? [])
-      .map((price) => ({
-        ...product,
-        description: convert(product.description),
-        priceId: price.id,
-        amount: price.amount,
-        type: price.type,
-        interval: price.interval,
-        intervalCount: price.intervalCount,
-        currency: price.currency,
-      }))
-      .sort((a, b) => a.amount - b.amount) // sort by amount in asc order
-  }
-
   async getFlattenProductList(
     limit: number,
     nextToken?: string,
   ): Promise<ProductFlattenArrayResponseType> {
-    // get all the products from copilot
     const copilot = new CopilotAPI(this.user.token)
-    const products = await copilot.getProducts(undefined, nextToken, limit)
-    let flattenProductsPrice: ProductFlattenArrayResponseType = {
-      products: [],
-    }
-    const flatmapProductPrice = []
-    if (products?.data) {
-      for (const product of products.data) {
-        flatmapProductPrice.push(
-          bottleneck.schedule(() => {
-            return this.getFlatMapforAProduct(product, copilot)
-          }),
-        )
-      }
-      flattenProductsPrice = {
-        products: (await Promise.all(flatmapProductPrice)).flat(),
-      }
-    }
 
-    return flattenProductsPrice
+    const [products, pricesByProduct] = await Promise.all([
+      copilot.getProducts(undefined, nextToken, limit),
+      this.fetchAllPricesGroupedByProduct(copilot),
+    ])
+
+    const flattened = (products?.data ?? []).flatMap((product) => {
+      const prices = pricesByProduct.get(product.id) ?? []
+      const productDescription = convert(product.description)
+      return prices
+        .map((price) => ({
+          ...product,
+          description: productDescription,
+          priceId: price.id,
+          amount: price.amount,
+          type: price.type,
+          interval: price.interval,
+          intervalCount: price.intervalCount,
+          currency: price.currency,
+        }))
+        .sort((a, b) => a.amount - b.amount) // sort by amount in asc order
+    })
+
+    return { products: flattened }
+  }
+
+  private async fetchAllPricesGroupedByProduct(
+    copilot: CopilotAPI,
+  ): Promise<Map<string, PriceResponse[]>> {
+    const grouped = new Map<string, PriceResponse[]>()
+    let nextToken: string | undefined
+    do {
+      const page = await copilot.getPrices(
+        undefined,
+        nextToken,
+        MAX_PRODUCT_LIST_LIMIT.toString(),
+      )
+      if (!page) {
+        // Transient SDK failure: bail rather than silently dropping every
+        // product on the page from the flattened response.
+        console.warn(
+          'fetchAllPricesGroupedByProduct | getPrices returned undefined; aborting pagination',
+        )
+        break
+      }
+      for (const price of page.data ?? []) {
+        const list = grouped.get(price.productId)
+        if (list) {
+          list.push(price)
+        } else {
+          grouped.set(price.productId, [price])
+        }
+      }
+      nextToken = page.nextToken
+    } while (nextToken)
+
+    return grouped
   }
 
   /**

--- a/src/app/api/quickbooks/product/product.service.ts
+++ b/src/app/api/quickbooks/product/product.service.ts
@@ -319,7 +319,7 @@ export class ProductService extends BaseService {
     return await intuitApi.createItem(qbItemPayload)
   }
 
-  async getFlattenProductList(): Promise<ProductFlattenArrayResponseType> {
+  async getProductsWithPrices(): Promise<ProductFlattenArrayResponseType> {
     const copilot = new CopilotAPI(this.user.token)
 
     const [products, pricesByProduct] = await Promise.all([
@@ -351,7 +351,7 @@ export class ProductService extends BaseService {
    * Walks every page of the workspace's /prices endpoint and groups by
    * productId. Replaces the prior bottleneck-throttled N+1 per-product fetch
    * with ceil(totalPrices / MAX_PRODUCT_LIST_LIMIT) sequential calls, which is
-   * dramatically faster for the single-page workload getFlattenProductList
+   * dramatically faster for the single-page workload getProductsWithPrices
    * actually serves. If product pagination is ever reintroduced, revisit:
    * caller would repeat this full walk per page with no cross-call cache.
    */

--- a/src/app/api/quickbooks/product/product.service.ts
+++ b/src/app/api/quickbooks/product/product.service.ts
@@ -319,14 +319,11 @@ export class ProductService extends BaseService {
     return await intuitApi.createItem(qbItemPayload)
   }
 
-  async getFlattenProductList(
-    limit: number,
-    nextToken?: string,
-  ): Promise<ProductFlattenArrayResponseType> {
+  async getFlattenProductList(): Promise<ProductFlattenArrayResponseType> {
     const copilot = new CopilotAPI(this.user.token)
 
     const [products, pricesByProduct] = await Promise.all([
-      copilot.getProducts(undefined, nextToken, limit),
+      copilot.getProducts(undefined, undefined, MAX_PRODUCT_LIST_LIMIT),
       this.fetchAllPricesGroupedByProduct(copilot),
     ])
 
@@ -350,6 +347,14 @@ export class ProductService extends BaseService {
     return { products: flattened }
   }
 
+  /**
+   * Walks every page of the workspace's /prices endpoint and groups by
+   * productId. Replaces the prior bottleneck-throttled N+1 per-product fetch
+   * with ceil(totalPrices / MAX_PRODUCT_LIST_LIMIT) sequential calls, which is
+   * dramatically faster for the single-page workload getFlattenProductList
+   * actually serves. If product pagination is ever reintroduced, revisit:
+   * caller would repeat this full walk per page with no cross-call cache.
+   */
   private async fetchAllPricesGroupedByProduct(
     copilot: CopilotAPI,
   ): Promise<Map<string, PriceResponse[]>> {

--- a/src/components/dashboard/Main.tsx
+++ b/src/components/dashboard/Main.tsx
@@ -1,16 +1,11 @@
 'use client'
+import Loading from '@/app/(home)/loading'
 import SettingAccordion from '@/components/dashboard/settings/SettingAccordion'
 import { CalloutVariant } from '@/components/type/callout'
 import Divider from '@/components/ui/Divider'
 import { useDashboardMain } from '@/hook/useDashboard'
 
-import {
-  ButtonProps,
-  Callout,
-  Heading,
-  IconType,
-  Spinner,
-} from 'copilot-design-system'
+import { ButtonProps, Callout, Heading, IconType } from 'copilot-design-system'
 import LastSyncAt from '@/components/dashboard/LastSyncAt'
 import { SilentError } from '@/components/template/SilentError'
 import { useApp } from '@/app/context/AppContext'
@@ -85,9 +80,7 @@ export const Main = () => {
   return (
     <>
       {isLoading ? (
-        <div className="loading-spinner h-screen flex items-center justify-center">
-          <Spinner size={10} />
-        </div>
+        <Loading />
       ) : (
         <main className="main-section px-8 sm:px-[100px] lg:px-[220px] pb-[54px] pt-6">
           {nonUsCompany && (


### PR DESCRIPTION
## Summary
- Parallelize portal connection check, workspace info fetch, and latest sync log lookup on the home server component (`src/app/(home)/Home.tsx`); replace internal API round-trip with direct `SyncLogService` call.
- Batch Copilot price fetching in `ProductService.getFlattenProductList` — paginate `/prices` once and group by `productId` instead of N+1 calls per product (drops `bottleneck`).
- Add a `loading.tsx` for the home segment and reuse it from `dashboard/Main`; drop the now-unused `checkSyncStatus` action (sync flag now read from the eagerly-loaded portal connection's setting).

## Test plan
- [x] Load the home route signed in to a portal that has an active QBO connection — verify spinner renders during streaming, then dashboard hydrates with the correct sync flag, enabled state, and last-sync timestamp.
- [x] Load the home route signed in to a portal with no QBO connection — verify connect CTA renders and `reconnect` flow still triggers when `?type=...` is passed.
- [x] Open the products page / any view that calls `getFlattenProductList` and confirm products with multiple prices still render every price row, sorted ascending by amount.
- [x] Confirm Copilot price pagination terminates: portal with >100 prices should still return all of them (paginate via `nextToken`).
- [x] `yarn lint:check && yarn test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)