### PR TITLE
OUT-3703: skip expired refresh tokens in cron sweep

### DIFF
--- a/src/db/service/token.service.ts
+++ b/src/db/service/token.service.ts
@@ -73,6 +73,12 @@ export const getPortalsWithExpiringRefreshTokens = async (
         eq(QBSetting.syncFlag, true),
         sql`${QBPortalConnection.tokenSetTime} + (${QBPortalConnection.XRefreshTokenExpiresIn} || ' seconds')::interval
             < now() + (${daysRemaining} || ' days')::interval`,
+        // Lower bound: already-expired tokens get `invalid_grant` from
+        // Intuit and never recover — they need an IU reconnect. Filtering
+        // here (not in the loop) keeps them invisible to ORDER BY and
+        // LIMIT so live portals aren't starved. See docs/qb-refresh-token-cron.md.
+        sql`${QBPortalConnection.tokenSetTime} + (${QBPortalConnection.XRefreshTokenExpiresIn} || ' seconds')::interval
+            > now()`,
       ),
     )
     .orderBy(asc(QBPortalConnection.tokenSetTime))

--- a/test/integration/quickbooks/refreshTokens/expiringSweep.test.ts
+++ b/test/integration/quickbooks/refreshTokens/expiringSweep.test.ts
@@ -163,10 +163,12 @@ describe('GET /api/quickbooks/refresh-tokens', () => {
 
     const res = await callCron({ authorization: CRON_AUTH })
     expect(res.status).toBe(200)
-    await expect(res.json()).resolves.toMatchObject({
+    await expect(res.json()).resolves.toEqual({
+      success: true,
       scanned: 0,
       refreshed: 0,
       reconnectRequired: 0,
+      errored: 0,
     })
     expect(getRefreshedQBToken).not.toHaveBeenCalled()
   })

--- a/test/integration/quickbooks/refreshTokens/expiringSweep.test.ts
+++ b/test/integration/quickbooks/refreshTokens/expiringSweep.test.ts
@@ -148,6 +148,29 @@ describe('GET /api/quickbooks/refresh-tokens', () => {
     expect(safe[0].refreshToken).toBe('old-safe')
   })
 
+  it('skips portals whose refresh token has already expired', async () => {
+    // Refresh tokens past TTL get `invalid_grant` from Intuit — they need
+    // an IU reconnect, not another refresh attempt. Without this filter
+    // they'd be swept daily, wasting Intuit calls and firing Sentry alerts.
+    // See docs/qb-refresh-token-cron.md.
+    await seedPortalConnection({
+      portalId: 'p-expired',
+      intuitRealmId: 'realm-expired',
+      refreshToken: 'old-expired',
+      tokenSetTime: tokenSetTimeForDaysToExpiry(-1), // 1 day past expiry
+    })
+    await seedSetting({ portalId: 'p-expired', syncFlag: true })
+
+    const res = await callCron({ authorization: CRON_AUTH })
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toMatchObject({
+      scanned: 0,
+      refreshed: 0,
+      reconnectRequired: 0,
+    })
+    expect(getRefreshedQBToken).not.toHaveBeenCalled()
+  })
+
   it('skips soft-deleted portals, portals without settings, and portals with syncFlag=false', async () => {
     // Three exclusion paths the selector enforces:
     //   - soft-deleted rows: off-limits to all background jobs.


### PR DESCRIPTION
## Summary

- The daily refresh-token cron's selector matched any portal where `tokenSetTime + ttl < now() + 14 days`, which also includes refresh tokens already past their TTL. Intuit rejects those with `invalid_grant` — they need an IU reconnect, not another refresh — so each daily run re-fired `QBReconnectRequiredError` to Sentry and (worse, via `ORDER BY tokenSetTime ASC`) let those dead portals claim slots from the per-run batch budget ahead of live portals.
- Add a SQL lower bound (`tokenSetTime + (x_refresh_token_expires_in || ' seconds')::interval > now()`) so expired rows are invisible to both `ORDER BY` and `LIMIT`. SQL-level filter chosen specifically because of the `ORDER BY` interaction — an in-loop guard would still let dead portals win the top of the queue.
- Linear: [OUT-3703](https://linear.app/assemblycom/issue/OUT-3703).

## Test plan

- [x] New integration test `'skips portals whose refresh token has already expired'` in `test/integration/quickbooks/refreshTokens/expiringSweep.test.ts`. Seeds a portal at `daysToExpiry = -1` and asserts `scanned: 0, refreshed: 0`, no Intuit call.
- [x] TDD red→green verified: test failed before the SQL change (`scanned: 1, refreshed: 1`), passes after.
- [x] Full file: 4/4 integration tests pass.
- [x] Related unit suites pass 16/16 (`test/unit/api/quickbooks/refresh-tokens/`, `test/unit/utils/tokenRefresh.test.ts`).
- [x] `yarn lint:check` and `yarn prettier:check` clean.

## Out of scope

- Mid-window manual revocations (IU disconnects in Intuit's admin UI while still inside the 14-day window) will still surface — one Sentry event per portal per run. If that becomes noisy, the follow-up is to persist revocation state on `qb_portal_connections` so each portal alerts once until reconnected.
- Auto-suspending revoked portals and IU notification remain the existing `AuthService` path's responsibility (it has Copilot user context; the cron does not). See `docs/qb-refresh-token-cron.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)