### PR TITLE
OUT-3709: drop placeholder errorMessage on stale PENDING flip

### DIFF
--- a/src/app/api/quickbooks/syncLog/syncLog.service.ts
+++ b/src/app/api/quickbooks/syncLog/syncLog.service.ts
@@ -199,7 +199,6 @@ export class SyncLogService extends BaseService {
       .update(QBSyncLog)
       .set({
         status: LogStatus.FAILED,
-        errorMessage: 'Stale PENDING claim — worker did not finalise in time',
         category: FailedRecordCategoryType.OTHERS,
       })
       .where(


### PR DESCRIPTION
## Summary
- `flipStalePendingToFailed` previously stamped `errorMessage: 'Stale PENDING claim — worker did not finalise in time'` onto `qb_sync_logs` when recovering stale PENDING rows.
- `SyncService.intiateSync` reads `currentLog.errorMessage` when reporting to Sentry on the final retry attempt (`sync.service.ts:479`), so that placeholder was being surfaced as if it were the real exception — misleading on-call (e.g. [ACCOUNTING-SYNC-3M](https://copilot-platforms.sentry.io/issues/7467720653)).
- Drop the placeholder. The flip still sets `status: FAILED` and `category: OTHERS`; the first retry that actually throws will populate `errorMessage` with the real reason via `updateFailedSyncLog`.

## Out of scope
- Silent early-return paths in `processInvoiceDeleted` / `processInvoiceVoided` (`!invoiceSync.customer`) that never overwrite `errorMessage` on retry. With this change, those rows now surface `null` in Sentry instead of the misleading placeholder — uninformative, but no longer misleading. Cleanup deferred to a follow-up ticket.

## Test plan
- [ ] Existing unit + integration tests still pass (`yarn test`).
- [ ] Lint + prettier clean (`yarn lint:check`, `yarn prettier:check`).
- [ ] Manual: in next stale-recovery cycle, verify newly flipped rows have `error_message = NULL` and the next retry either fills it with a real exception or flips to SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)