### PR TITLE
OUT-3543: Type and Zod-validate IntuitAPI responses

### DIFF
--- a/src/app/api/quickbooks/product/product.controller.ts
+++ b/src/app/api/quickbooks/product/product.controller.ts
@@ -47,7 +47,6 @@ export async function getItemsFromQB(req: NextRequest) {
   const items = await productService.queryItemsFromQB(
     qbTokenInfo,
     MAX_PRODUCT_LIST_LIMIT,
-    ['Id', 'Name', 'UnitPrice', 'SyncToken', 'Description'],
   )
   return NextResponse.json(items)
 }

--- a/src/app/api/quickbooks/product/product.service.ts
+++ b/src/app/api/quickbooks/product/product.service.ts
@@ -646,13 +646,9 @@ export class ProductService extends BaseService {
     })
   }
 
-  async queryItemsFromQB(
-    qbTokenInfo: IntuitAPITokensType,
-    limit: number,
-    columns: string[],
-  ) {
+  async queryItemsFromQB(qbTokenInfo: IntuitAPITokensType, limit: number) {
     const intuitApi = new IntuitAPI(qbTokenInfo)
-    return await intuitApi.getAllItems(limit, columns)
+    return await intuitApi.getAllItems(limit)
   }
 
   async formatAndSyncProductLogs(payload: ProductChangedItemReferenceType[]) {

--- a/src/cmd/backfillProductInfo/backfillProductInfo.service.ts
+++ b/src/cmd/backfillProductInfo/backfillProductInfo.service.ts
@@ -69,13 +69,7 @@ export class BackfillProductInfoService extends BaseService {
       }
 
       const intuitApi = new IntuitAPI(qbTokenInfo)
-      const allQbItems = await intuitApi.getAllItems(MAX_PRODUCT_LIST_LIMIT, [
-        'Id',
-        'Name',
-        'UnitPrice',
-        'Description',
-        'SyncToken',
-      ])
+      const allQbItems = await intuitApi.getAllItems(MAX_PRODUCT_LIST_LIMIT)
 
       // 3. update the product info in our mapping table
       for (const mappedProduct of mappedProducts) {

--- a/src/helper/fetch.helper.ts
+++ b/src/helper/fetch.helper.ts
@@ -77,7 +77,7 @@ const resolveSignal = (opts: FetcherOptions): AbortSignal | undefined => {
 export const postFetcher = async (
   url: string,
   headers: Record<string, string>,
-  body: Record<string, any>,
+  body: Record<string, unknown>,
   opts: FetcherOptions = {},
 ) => {
   const response = await fetch(url, {

--- a/src/type/dto/intuitAPI.dto.ts
+++ b/src/type/dto/intuitAPI.dto.ts
@@ -8,6 +8,16 @@ export const QBNameValueSchema = z.object({
 })
 export type QBNameValueSchemaType = z.infer<typeof QBNameValueSchema>
 
+// QBO returns Fault on any failed response. Error is loose (object or array)
+// across endpoints; we forward whatever shape arrived so callers/log
+// consumers can inspect it.
+export const QBFaultSchema = z.object({
+  Fault: z.object({
+    Error: z.unknown().optional(),
+  }),
+})
+export type QBFaultType = z.infer<typeof QBFaultSchema>
+
 export const QBInvoiceLineItemSchema = z.object({
   DetailType: z.string(),
   Amount: z.number(),
@@ -103,7 +113,7 @@ export const QBItemRowSchema = z.object({
   ClassRef: QBNameValueSchema.optional(),
   Active: z.boolean().optional(),
   UnitPrice: z.number(),
-  Description: z.string().optional(),
+  Description: z.string().nullish(),
 })
 export type QBItemRowType = z.infer<typeof QBItemRowSchema>
 
@@ -248,22 +258,14 @@ export type CustomerQueryResponseType = z.infer<
   typeof CustomerQueryResponseSchema
 >
 
-export const CustomerListRowSchema = z.object({
-  Id: z.string(),
-  SyncToken: z.string(),
-  Active: z.boolean(),
-  CompanyName: z.string().optional(),
-  FullyQualifiedName: z.string().optional(),
-  PrimaryEmailAddr: z
-    .object({
-      Address: z.string(),
-    })
-    .optional(),
+// Envelope returned by createCustomer / customerSparseUpdate.
+export const QBCustomerResponseSchema = z.object({
+  Customer: CustomerQueryResponseSchema,
 })
-export type CustomerListRowType = z.infer<typeof CustomerListRowSchema>
+export type QBCustomerResponseType = z.infer<typeof QBCustomerResponseSchema>
 
 export const CustomerListEnvelopeSchema = z.object({
-  Customer: z.array(CustomerListRowSchema).optional(),
+  Customer: z.array(CustomerQueryResponseSchema).optional(),
 })
 export type CustomerListEnvelopeType = z.infer<
   typeof CustomerListEnvelopeSchema
@@ -285,7 +287,6 @@ export type QBInvoiceRowType = z.infer<typeof QBInvoiceRowSchema>
 // Envelope returned by createInvoice / invoiceSparseUpdate / voidInvoice.
 export const QBInvoiceResponseSchema = z.object({
   Invoice: QBInvoiceRowSchema,
-  time: z.string().optional(),
 })
 export type QBInvoiceResponseType = z.infer<typeof QBInvoiceResponseSchema>
 
@@ -305,7 +306,6 @@ export const QBInvoiceDeleteResponseSchema = z.object({
     status: z.string().optional(),
     domain: z.string().optional(),
   }),
-  time: z.string().optional(),
 })
 export type QBInvoiceDeleteResponseType = z.infer<
   typeof QBInvoiceDeleteResponseSchema
@@ -323,7 +323,6 @@ export type QBPurchaseRowType = z.infer<typeof QBPurchaseRowSchema>
 
 export const QBPurchaseResponseSchema = z.object({
   Purchase: QBPurchaseRowSchema,
-  time: z.string().optional(),
 })
 export type QBPurchaseResponseType = z.infer<typeof QBPurchaseResponseSchema>
 
@@ -333,7 +332,6 @@ export const QBPurchaseDeleteResponseSchema = z.object({
     status: z.string().optional(),
     domain: z.string().optional(),
   }),
-  time: z.string().optional(),
 })
 export type QBPurchaseDeleteResponseType = z.infer<
   typeof QBPurchaseDeleteResponseSchema
@@ -365,7 +363,6 @@ export type QBPaymentRowType = z.infer<typeof QBPaymentRowSchema>
 
 export const QBPaymentResponseSchema = z.object({
   Payment: QBPaymentRowSchema,
-  time: z.string().optional(),
 })
 export type QBPaymentResponseType = z.infer<typeof QBPaymentResponseSchema>
 
@@ -375,7 +372,6 @@ export const QBPaymentDeleteResponseSchema = z.object({
     status: z.string().optional(),
     domain: z.string().optional(),
   }),
-  time: z.string().optional(),
 })
 export type QBPaymentDeleteResponseType = z.infer<
   typeof QBPaymentDeleteResponseSchema

--- a/src/type/dto/intuitAPI.dto.ts
+++ b/src/type/dto/intuitAPI.dto.ts
@@ -253,6 +253,34 @@ export type CustomerQueryResponseType = z.infer<
   typeof CustomerQueryResponseSchema
 >
 
+// Envelope row used for the paginated email walk. PrimaryEmailAddr.Address is
+// `unknown` (not `z.string()`) because mid-walk we tolerate QBO returning
+// malformed rows (null/number/missing Address) without failing the whole page;
+// the find() predicate narrows with `typeof addr === 'string'`.
+export const CustomerListRowSchema = z
+  .object({
+    Id: z.string(),
+    SyncToken: z.string(),
+    Active: z.boolean(),
+    CompanyName: z.string().optional(),
+    FullyQualifiedName: z.string().optional(),
+    PrimaryEmailAddr: z
+      .object({
+        Address: z.unknown(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough()
+export type CustomerListRowType = z.infer<typeof CustomerListRowSchema>
+
+export const CustomerListEnvelopeSchema = z.object({
+  Customer: z.array(CustomerListRowSchema).optional(),
+})
+export type CustomerListEnvelopeType = z.infer<
+  typeof CustomerListEnvelopeSchema
+>
+
 export const QBInvoiceRowSchema = z
   .object({
     Id: z.string(),
@@ -274,6 +302,15 @@ export const QBInvoiceResponseSchema = z.object({
   time: z.string().optional(),
 })
 export type QBInvoiceResponseType = z.infer<typeof QBInvoiceResponseSchema>
+
+// Envelope returned by customQuery for SELECT ... FROM Invoice. Invoice is
+// optional because QBO omits the key when there are zero results.
+export const QBInvoiceQueryResponseSchema = z.object({
+  Invoice: z.array(QBInvoiceRowSchema).optional(),
+})
+export type QBInvoiceQueryResponseType = z.infer<
+  typeof QBInvoiceQueryResponseSchema
+>
 
 // Envelope returned by deleteInvoice (no full row, just deletion confirmation).
 export const QBInvoiceDeleteResponseSchema = z.object({

--- a/src/type/dto/intuitAPI.dto.ts
+++ b/src/type/dto/intuitAPI.dto.ts
@@ -248,10 +248,6 @@ export type CustomerQueryResponseType = z.infer<
   typeof CustomerQueryResponseSchema
 >
 
-// Envelope row used for the paginated email walk. PrimaryEmailAddr.Address is
-// `unknown` (not `z.string()`) because mid-walk we tolerate QBO returning
-// malformed rows (null/number/missing Address) without failing the whole page;
-// the find() predicate narrows with `typeof addr === 'string'`.
 export const CustomerListRowSchema = z.object({
   Id: z.string(),
   SyncToken: z.string(),

--- a/src/type/dto/intuitAPI.dto.ts
+++ b/src/type/dto/intuitAPI.dto.ts
@@ -285,11 +285,79 @@ export type QBInvoiceDeleteResponseType = z.infer<
   typeof QBInvoiceDeleteResponseSchema
 >
 
+export const QBPurchaseRowSchema = z
+  .object({
+    Id: z.string(),
+    SyncToken: z.string().optional(),
+    TotalAmt: z.number(),
+    TxnDate: z.string().optional(),
+    AccountRef: QBNameValueSchema.optional(),
+    PaymentType: z.string().optional(),
+  })
+  .passthrough()
+export type QBPurchaseRowType = z.infer<typeof QBPurchaseRowSchema>
+
 export const QBPurchaseResponseSchema = z.object({
-  Id: z.string(),
-  TotalAmt: z.number(),
+  Purchase: QBPurchaseRowSchema,
+  time: z.string().optional(),
 })
 export type QBPurchaseResponseType = z.infer<typeof QBPurchaseResponseSchema>
+
+export const QBPurchaseDeleteResponseSchema = z.object({
+  Purchase: z.object({
+    Id: z.string(),
+    status: z.string().optional(),
+    domain: z.string().optional(),
+  }),
+  time: z.string().optional(),
+})
+export type QBPurchaseDeleteResponseType = z.infer<
+  typeof QBPurchaseDeleteResponseSchema
+>
+
+export const QBPaymentRowSchema = z
+  .object({
+    Id: z.string(),
+    SyncToken: z.string().optional(),
+    TotalAmt: z.number(),
+    TxnDate: z.string().optional(),
+    CustomerRef: QBNameValueSchema.optional(),
+    Line: z
+      .array(
+        z.object({
+          Amount: z.number().optional(),
+          LinkedTxn: z
+            .array(
+              z.object({
+                TxnId: z.string(),
+                TxnType: z.string(),
+              }),
+            )
+            .optional(),
+        }),
+      )
+      .optional(),
+  })
+  .passthrough()
+export type QBPaymentRowType = z.infer<typeof QBPaymentRowSchema>
+
+export const QBPaymentResponseSchema = z.object({
+  Payment: QBPaymentRowSchema,
+  time: z.string().optional(),
+})
+export type QBPaymentResponseType = z.infer<typeof QBPaymentResponseSchema>
+
+export const QBPaymentDeleteResponseSchema = z.object({
+  Payment: z.object({
+    Id: z.string(),
+    status: z.string().optional(),
+    domain: z.string().optional(),
+  }),
+  time: z.string().optional(),
+})
+export type QBPaymentDeleteResponseType = z.infer<
+  typeof QBPaymentDeleteResponseSchema
+>
 
 export const QBItemsResponseSchema = z.array(
   z.object({

--- a/src/type/dto/intuitAPI.dto.ts
+++ b/src/type/dto/intuitAPI.dto.ts
@@ -377,3 +377,6 @@ export const SingleIdAndTokenResponseSchema = z.object({
   Id: z.string(),
   SyncToken: z.string(),
 })
+export type SingleIdAndTokenResponseType = z.infer<
+  typeof SingleIdAndTokenResponseSchema
+>

--- a/src/type/dto/intuitAPI.dto.ts
+++ b/src/type/dto/intuitAPI.dto.ts
@@ -96,16 +96,15 @@ export type QBItemFullUpdatePayloadType = z.infer<
   typeof QBItemFullUpdatePayloadSchema
 >
 
-export const QBItemRowSchema = z
-  .object({
-    Id: z.string(),
-    SyncToken: z.string(),
-    Name: z.string(),
-    ClassRef: QBNameValueSchema.optional(),
-    Active: z.boolean(),
-    UnitPrice: z.number(),
-  })
-  .passthrough()
+export const QBItemRowSchema = z.object({
+  Id: z.string(),
+  SyncToken: z.string(),
+  Name: z.string(),
+  ClassRef: QBNameValueSchema.optional(),
+  Active: z.boolean().optional(),
+  UnitPrice: z.number(),
+  Description: z.string().optional(),
+})
 export type QBItemRowType = z.infer<typeof QBItemRowSchema>
 
 export const QBItemResponseSchema = z.object({
@@ -176,14 +175,12 @@ export type QBAccountUpdatePayloadType = z.infer<
   typeof QBAccountUpdatePayloadSchema
 >
 
-export const QBAccountRowSchema = z
-  .object({
-    Id: z.string(),
-    Name: z.string(),
-    SyncToken: z.string(),
-    Active: z.boolean(),
-  })
-  .passthrough()
+export const QBAccountRowSchema = z.object({
+  Id: z.string(),
+  Name: z.string(),
+  SyncToken: z.string(),
+  Active: z.boolean(),
+})
 export type QBAccountRowType = z.infer<typeof QBAccountRowSchema>
 
 export const QBAccountResponseSchema = z.object({
@@ -228,26 +225,24 @@ export type QBDeletePayloadType = z.infer<typeof QBDeletePayloadSchema>
 export const CompanyInfoSchema = z.object({
   CompanyInfo: z.array(
     z.object({
-      Country: z.string(),
+      Country: z.string().optional(),
     }),
   ),
 })
 export type CompanyInfoType = z.infer<typeof CompanyInfoSchema>
 
-export const CustomerQueryResponseSchema = z
-  .object({
-    Id: z.string(),
-    SyncToken: z.string(),
-    Active: z.boolean(),
-    CompanyName: z.string().optional(),
-    FullyQualifiedName: z.string().optional(),
-    PrimaryEmailAddr: z
-      .object({
-        Address: z.string(),
-      })
-      .optional(),
-  })
-  .passthrough()
+export const CustomerQueryResponseSchema = z.object({
+  Id: z.string(),
+  SyncToken: z.string(),
+  Active: z.boolean(),
+  CompanyName: z.string().optional(),
+  FullyQualifiedName: z.string().optional(),
+  PrimaryEmailAddr: z
+    .object({
+      Address: z.string(),
+    })
+    .optional(),
+})
 
 export type CustomerQueryResponseType = z.infer<
   typeof CustomerQueryResponseSchema
@@ -257,21 +252,18 @@ export type CustomerQueryResponseType = z.infer<
 // `unknown` (not `z.string()`) because mid-walk we tolerate QBO returning
 // malformed rows (null/number/missing Address) without failing the whole page;
 // the find() predicate narrows with `typeof addr === 'string'`.
-export const CustomerListRowSchema = z
-  .object({
-    Id: z.string(),
-    SyncToken: z.string(),
-    Active: z.boolean(),
-    CompanyName: z.string().optional(),
-    FullyQualifiedName: z.string().optional(),
-    PrimaryEmailAddr: z
-      .object({
-        Address: z.unknown(),
-      })
-      .passthrough()
-      .optional(),
-  })
-  .passthrough()
+export const CustomerListRowSchema = z.object({
+  Id: z.string(),
+  SyncToken: z.string(),
+  Active: z.boolean(),
+  CompanyName: z.string().optional(),
+  FullyQualifiedName: z.string().optional(),
+  PrimaryEmailAddr: z
+    .object({
+      Address: z.string(),
+    })
+    .optional(),
+})
 export type CustomerListRowType = z.infer<typeof CustomerListRowSchema>
 
 export const CustomerListEnvelopeSchema = z.object({
@@ -281,19 +273,17 @@ export type CustomerListEnvelopeType = z.infer<
   typeof CustomerListEnvelopeSchema
 >
 
-export const QBInvoiceRowSchema = z
-  .object({
-    Id: z.string(),
-    SyncToken: z.string(),
-    DocNumber: z.string().optional(),
-    Balance: z.number().optional(),
-    TotalAmt: z.number().optional(),
-    TxnDate: z.string().optional(),
-    DueDate: z.string().optional(),
-    PrivateNote: z.string().optional(),
-    CustomerRef: QBNameValueSchema.optional(),
-  })
-  .passthrough()
+export const QBInvoiceRowSchema = z.object({
+  Id: z.string(),
+  SyncToken: z.string(),
+  DocNumber: z.string().optional(),
+  Balance: z.number().optional(),
+  TotalAmt: z.number().optional(),
+  TxnDate: z.string().optional(),
+  DueDate: z.string().optional(),
+  PrivateNote: z.string().optional(),
+  CustomerRef: QBNameValueSchema.optional(),
+})
 export type QBInvoiceRowType = z.infer<typeof QBInvoiceRowSchema>
 
 // Envelope returned by createInvoice / invoiceSparseUpdate / voidInvoice.
@@ -325,16 +315,14 @@ export type QBInvoiceDeleteResponseType = z.infer<
   typeof QBInvoiceDeleteResponseSchema
 >
 
-export const QBPurchaseRowSchema = z
-  .object({
-    Id: z.string(),
-    SyncToken: z.string(),
-    TotalAmt: z.number(),
-    TxnDate: z.string().optional(),
-    AccountRef: QBNameValueSchema.optional(),
-    PaymentType: z.string().optional(),
-  })
-  .passthrough()
+export const QBPurchaseRowSchema = z.object({
+  Id: z.string(),
+  SyncToken: z.string(),
+  TotalAmt: z.number(),
+  TxnDate: z.string().optional(),
+  AccountRef: QBNameValueSchema.optional(),
+  PaymentType: z.string().optional(),
+})
 export type QBPurchaseRowType = z.infer<typeof QBPurchaseRowSchema>
 
 export const QBPurchaseResponseSchema = z.object({
@@ -355,30 +343,28 @@ export type QBPurchaseDeleteResponseType = z.infer<
   typeof QBPurchaseDeleteResponseSchema
 >
 
-export const QBPaymentRowSchema = z
-  .object({
-    Id: z.string(),
-    SyncToken: z.string().optional(),
-    TotalAmt: z.number(),
-    TxnDate: z.string().optional(),
-    CustomerRef: QBNameValueSchema.optional(),
-    Line: z
-      .array(
-        z.object({
-          Amount: z.number().optional(),
-          LinkedTxn: z
-            .array(
-              z.object({
-                TxnId: z.string(),
-                TxnType: z.string(),
-              }),
-            )
-            .optional(),
-        }),
-      )
-      .optional(),
-  })
-  .passthrough()
+export const QBPaymentRowSchema = z.object({
+  Id: z.string(),
+  SyncToken: z.string(),
+  TotalAmt: z.number(),
+  TxnDate: z.string().optional(),
+  CustomerRef: QBNameValueSchema.optional(),
+  Line: z
+    .array(
+      z.object({
+        Amount: z.number().optional(),
+        LinkedTxn: z
+          .array(
+            z.object({
+              TxnId: z.string(),
+              TxnType: z.string(),
+            }),
+          )
+          .optional(),
+      }),
+    )
+    .optional(),
+})
 export type QBPaymentRowType = z.infer<typeof QBPaymentRowSchema>
 
 export const QBPaymentResponseSchema = z.object({

--- a/src/type/dto/intuitAPI.dto.ts
+++ b/src/type/dto/intuitAPI.dto.ts
@@ -247,11 +247,15 @@ export const CustomerQueryResponseSchema = z.object({
   Active: z.boolean(),
   CompanyName: z.string().optional(),
   FullyQualifiedName: z.string().optional(),
+  // PrimaryEmailAddr and its Address are .nullish() because a single
+  // malformed row (null email object, or present-but-null Address) must not
+  // ZodError the entire paginated walk in _getCustomerByEmail. The find()
+  // predicate narrows with `typeof addr === 'string'`.
   PrimaryEmailAddr: z
     .object({
-      Address: z.string(),
+      Address: z.string().nullish(),
     })
-    .optional(),
+    .nullish(),
 })
 
 export type CustomerQueryResponseType = z.infer<

--- a/src/type/dto/intuitAPI.dto.ts
+++ b/src/type/dto/intuitAPI.dto.ts
@@ -328,7 +328,7 @@ export type QBInvoiceDeleteResponseType = z.infer<
 export const QBPurchaseRowSchema = z
   .object({
     Id: z.string(),
-    SyncToken: z.string().optional(),
+    SyncToken: z.string(),
     TotalAmt: z.number(),
     TxnDate: z.string().optional(),
     AccountRef: QBNameValueSchema.optional(),

--- a/src/type/dto/intuitAPI.dto.ts
+++ b/src/type/dto/intuitAPI.dto.ts
@@ -96,17 +96,29 @@ export type QBItemFullUpdatePayloadType = z.infer<
   typeof QBItemFullUpdatePayloadSchema
 >
 
-export const QBItemResponseSchema = z.object({
-  Item: z.object({
+export const QBItemRowSchema = z
+  .object({
     Id: z.string(),
     SyncToken: z.string(),
     Name: z.string(),
     ClassRef: QBNameValueSchema.optional(),
     Active: z.boolean(),
     UnitPrice: z.number(),
-  }),
+  })
+  .passthrough()
+export type QBItemRowType = z.infer<typeof QBItemRowSchema>
+
+export const QBItemResponseSchema = z.object({
+  Item: QBItemRowSchema,
 })
 export type QBItemResponseType = z.infer<typeof QBItemResponseSchema>
+
+// Envelope returned by `customQuery` for `SELECT ... FROM Item`. Item is
+// optional because QBO omits the key when there are zero results.
+export const QBItemQueryResponseSchema = z.object({
+  Item: z.array(QBItemRowSchema).optional(),
+})
+export type QBItemQueryResponseType = z.infer<typeof QBItemQueryResponseSchema>
 
 export const QBPaymentCreatePayloadSchema = z.object({
   TotalAmt: z.number(),
@@ -164,15 +176,27 @@ export type QBAccountUpdatePayloadType = z.infer<
   typeof QBAccountUpdatePayloadSchema
 >
 
-export const QBAccountResponseSchema = z.object({
-  Account: z.object({
+export const QBAccountRowSchema = z
+  .object({
     Id: z.string(),
     Name: z.string(),
     SyncToken: z.string(),
     Active: z.boolean(),
-  }),
+  })
+  .passthrough()
+export type QBAccountRowType = z.infer<typeof QBAccountRowSchema>
+
+export const QBAccountResponseSchema = z.object({
+  Account: QBAccountRowSchema,
 })
 export type QBAccountResponseType = z.infer<typeof QBAccountResponseSchema>
+
+export const QBAccountQueryResponseSchema = z.object({
+  Account: z.array(QBAccountRowSchema).optional(),
+})
+export type QBAccountQueryResponseType = z.infer<
+  typeof QBAccountQueryResponseSchema
+>
 
 export const QBPurchaseCreatePayloadSchema = z.object({
   PaymentType: z.literal('Cash'),

--- a/src/type/dto/intuitAPI.dto.ts
+++ b/src/type/dto/intuitAPI.dto.ts
@@ -250,13 +250,40 @@ export type CustomerQueryResponseType = z.infer<
   typeof CustomerQueryResponseSchema
 >
 
+export const QBInvoiceRowSchema = z
+  .object({
+    Id: z.string(),
+    SyncToken: z.string(),
+    DocNumber: z.string().optional(),
+    Balance: z.number().optional(),
+    TotalAmt: z.number().optional(),
+    TxnDate: z.string().optional(),
+    DueDate: z.string().optional(),
+    PrivateNote: z.string().optional(),
+    CustomerRef: QBNameValueSchema.optional(),
+  })
+  .passthrough()
+export type QBInvoiceRowType = z.infer<typeof QBInvoiceRowSchema>
+
+// Envelope returned by createInvoice / invoiceSparseUpdate / voidInvoice.
 export const QBInvoiceResponseSchema = z.object({
-  Id: z.string(),
-  Balance: z.number(),
-  PrivateNote: z.string().optional(),
-  SyncToken: z.string(),
+  Invoice: QBInvoiceRowSchema,
+  time: z.string().optional(),
 })
 export type QBInvoiceResponseType = z.infer<typeof QBInvoiceResponseSchema>
+
+// Envelope returned by deleteInvoice (no full row, just deletion confirmation).
+export const QBInvoiceDeleteResponseSchema = z.object({
+  Invoice: z.object({
+    Id: z.string(),
+    status: z.string().optional(),
+    domain: z.string().optional(),
+  }),
+  time: z.string().optional(),
+})
+export type QBInvoiceDeleteResponseType = z.infer<
+  typeof QBInvoiceDeleteResponseSchema
+>
 
 export const QBPurchaseResponseSchema = z.object({
   Id: z.string(),

--- a/src/type/dto/intuitAPI.dto.ts
+++ b/src/type/dto/intuitAPI.dto.ts
@@ -234,17 +234,20 @@ export const CompanyInfoSchema = z.object({
 })
 export type CompanyInfoType = z.infer<typeof CompanyInfoSchema>
 
-export const CustomerQueryResponseSchema = z.object({
-  Id: z.string(),
-  SyncToken: z.string(),
-  Active: z.boolean(),
-  CompanyName: z.string().optional(),
-  PrimaryEmailAddr: z
-    .object({
-      Address: z.string(),
-    })
-    .optional(),
-})
+export const CustomerQueryResponseSchema = z
+  .object({
+    Id: z.string(),
+    SyncToken: z.string(),
+    Active: z.boolean(),
+    CompanyName: z.string().optional(),
+    FullyQualifiedName: z.string().optional(),
+    PrimaryEmailAddr: z
+      .object({
+        Address: z.string(),
+      })
+      .optional(),
+  })
+  .passthrough()
 
 export type CustomerQueryResponseType = z.infer<
   typeof CustomerQueryResponseSchema

--- a/src/utils/intuitAPI.ts
+++ b/src/utils/intuitAPI.ts
@@ -43,6 +43,7 @@ import {
   QBPurchaseDeleteResponseType,
   QBPurchaseDeleteResponseSchema,
   SingleIdAndTokenResponseSchema,
+  SingleIdAndTokenResponseType,
 } from '@/type/dto/intuitAPI.dto'
 import { escapeForQBQuery, getNameAsCustomer } from '@/utils/string'
 import CustomLogger from '@/utils/logger'
@@ -131,7 +132,9 @@ export default class IntuitAPI {
     return res.QueryResponse
   }
 
-  async _createInvoice(payload: QBInvoiceCreatePayloadType) {
+  async _createInvoice(
+    payload: QBInvoiceCreatePayloadType,
+  ): Promise<QBInvoiceResponseType> {
     CustomLogger.info({
       obj: { payload },
       message: `IntuitAPI#createInvoice | invoice creation start for realmId: ${this.tokens.intuitRealmId}.`,
@@ -148,11 +151,12 @@ export default class IntuitAPI {
       )
     }
 
+    const parsed = QBInvoiceResponseSchema.parse(invoice)
     CustomLogger.info({
-      obj: { response: invoice.Invoice },
-      message: `IntuitAPI#createInvoice | invoice created with doc number = ${invoice.Invoice?.DocNumber}.`,
+      obj: { response: parsed.Invoice },
+      message: `IntuitAPI#createInvoice | invoice created with doc number = ${parsed.Invoice?.DocNumber ?? ''}.`,
     })
-    return invoice
+    return parsed
   }
 
   async _createCustomer(
@@ -446,7 +450,9 @@ export default class IntuitAPI {
     return QBItemsResponseSchema.parse(qbItems.Item || [])
   }
 
-  async _invoiceSparseUpdate(payload: QBInvoiceSparseUpdatePayloadType) {
+  async _invoiceSparseUpdate(
+    payload: QBInvoiceSparseUpdatePayloadType,
+  ): Promise<QBInvoiceResponseType> {
     CustomLogger.info({
       obj: { payload },
       message: `IntuitAPI#InvoiceSparseUpdate | invoice sparse update start for realmId: ${this.tokens.intuitRealmId}. `,
@@ -463,11 +469,12 @@ export default class IntuitAPI {
       )
     }
 
+    const parsed = QBInvoiceResponseSchema.parse(invoice)
     CustomLogger.info({
-      obj: { response: invoice.Invoice },
-      message: `IntuitAPI#InvoiceSparseUpdate | invoice sparse updated for doc number = ${invoice.Invoice?.DocNumber}.`,
+      obj: { response: parsed.Invoice },
+      message: `IntuitAPI#InvoiceSparseUpdate | invoice sparse updated for doc number = ${parsed.Invoice?.DocNumber ?? ''}.`,
     })
-    return invoice
+    return parsed
   }
 
   async _customerSparseUpdate(
@@ -577,7 +584,9 @@ export default class IntuitAPI {
     return payment
   }
 
-  async _getInvoice(invoiceNumber: string) {
+  async _getInvoice(
+    invoiceNumber: string,
+  ): Promise<SingleIdAndTokenResponseType | null> {
     CustomLogger.info({
       obj: { invoiceNumber },
       message: `IntuitAPI#getInvoice | invoice query start for realmId: ${this.tokens.intuitRealmId}. `,
@@ -594,7 +603,9 @@ export default class IntuitAPI {
     return SingleIdAndTokenResponseSchema.parse(invoice.Invoice[0])
   }
 
-  async _voidInvoice(payload: QBDestructiveInvoicePayloadSchema) {
+  async _voidInvoice(
+    payload: QBDestructiveInvoicePayloadSchema,
+  ): Promise<QBInvoiceResponseType> {
     CustomLogger.info({
       obj: { payload },
       message: `IntuitAPI#voidInvoice | invoice void start for realmId: ${this.tokens.intuitRealmId}. `,
@@ -611,14 +622,17 @@ export default class IntuitAPI {
       )
     }
 
+    const parsed = QBInvoiceResponseSchema.parse(invoice)
     CustomLogger.info({
-      obj: { response: invoice.Invoice },
-      message: `IntuitAPI#voidInvoice | Voided invoice with Id = ${invoice.Invoice?.Id}.`,
+      obj: { response: parsed.Invoice },
+      message: `IntuitAPI#voidInvoice | Voided invoice with Id = ${parsed.Invoice.Id}.`,
     })
-    return invoice
+    return parsed
   }
 
-  async _deleteInvoice(payload: QBDestructiveInvoicePayloadSchema) {
+  async _deleteInvoice(
+    payload: QBDestructiveInvoicePayloadSchema,
+  ): Promise<QBInvoiceDeleteResponseType> {
     CustomLogger.info({
       obj: { payload },
       message: `IntuitAPI#deleteInvoice | invoice deletion start for realmId: ${this.tokens.intuitRealmId}. `,
@@ -635,11 +649,12 @@ export default class IntuitAPI {
       )
     }
 
+    const parsed = QBInvoiceDeleteResponseSchema.parse(invoice)
     CustomLogger.info({
-      obj: { response: invoice.Invoice },
-      message: `IntuitAPI#deleteInvoice | Deleted invoice with id = ${invoice.Invoice?.Id}. `,
+      obj: { response: parsed.Invoice },
+      message: `IntuitAPI#deleteInvoice | Deleted invoice with id = ${parsed.Invoice.Id}. `,
     })
-    return invoice
+    return parsed
   }
 
   async _deletePayment(payload: QBDeletePayloadType) {

--- a/src/utils/intuitAPI.ts
+++ b/src/utils/intuitAPI.ts
@@ -29,6 +29,7 @@ import {
   CustomerQueryResponseType,
   CustomerQueryResponseSchema,
   QBItemsResponseSchema,
+  QBItemsResponseType,
   QBInvoiceResponseType,
   QBInvoiceResponseSchema,
   QBInvoiceDeleteResponseType,
@@ -180,7 +181,7 @@ export default class IntuitAPI {
     return customer.Customer
   }
 
-  async _createItem(payload: QBItemCreatePayloadType) {
+  async _createItem(payload: QBItemCreatePayloadType): Promise<QBItemRowType> {
     CustomLogger.info({
       obj: { payload },
       message: `IntuitAPI#createItem | Item creation start for realmId: ${this.tokens.intuitRealmId}. Payload: `,
@@ -197,11 +198,12 @@ export default class IntuitAPI {
       )
     }
 
+    const parsed = QBItemResponseSchema.parse(item)
     CustomLogger.info({
-      obj: { response: item.Item },
-      message: `IntuitAPI#createItem | item created with Id = ${item?.Item?.Id}. Response: `,
+      obj: { response: parsed.Item },
+      message: `IntuitAPI#createItem | item created with Id = ${parsed.Item?.Id}. Response: `,
     })
-    return item.Item
+    return parsed.Item
   }
 
   async _getSingleIncomeAccount() {
@@ -418,10 +420,14 @@ export default class IntuitAPI {
 
     if (!qbItem) return null
 
-    return qbItem.Item?.[0]
+    const parsed = QBItemQueryResponseSchema.parse(qbItem)
+    return parsed.Item?.[0] ?? null
   }
 
-  async _getAllItems(limit: number, columns: string[] = ['Id']) {
+  async _getAllItems(
+    limit: number,
+    columns: string[] = ['Id'],
+  ): Promise<QBItemsResponseType | null> {
     CustomLogger.info({
       message: `IntuitAPI#getAllItems | Item query start for realmId: ${this.tokens.intuitRealmId}`,
     })

--- a/src/utils/intuitAPI.ts
+++ b/src/utils/intuitAPI.ts
@@ -174,11 +174,12 @@ export default class IntuitAPI {
       )
     }
 
+    const parsedCustomer = CustomerQueryResponseSchema.parse(customer.Customer)
     CustomLogger.info({
-      obj: { response: customer.Customer },
-      message: `IntuitAPI#createCustomer | customer created with name = ${customer.Customer?.FullyQualifiedName}.`,
+      obj: { response: parsedCustomer },
+      message: `IntuitAPI#createCustomer | customer created with name = ${parsedCustomer.FullyQualifiedName ?? ''}.`,
     })
-    return customer.Customer
+    return parsedCustomer
   }
 
   async _createItem(payload: QBItemCreatePayloadType): Promise<QBItemRowType> {
@@ -488,11 +489,12 @@ export default class IntuitAPI {
       )
     }
 
+    const parsedCustomer = CustomerQueryResponseSchema.parse(customer.Customer)
     CustomLogger.info({
-      obj: { response: customer.Customer },
-      message: `IntuitAPI#customerSparseUpdate | customer sparse updated with name = ${customer.Customer?.FullyQualifiedName}. `,
+      obj: { response: parsedCustomer },
+      message: `IntuitAPI#customerSparseUpdate | customer sparse updated with name = ${parsedCustomer.FullyQualifiedName ?? ''}. `,
     })
-    return customer.Customer
+    return parsedCustomer
   }
 
   async _itemFullUpdate(

--- a/src/utils/intuitAPI.ts
+++ b/src/utils/intuitAPI.ts
@@ -85,10 +85,13 @@ export function assertNotQBFault(raw: unknown, opName: string): void {
     typeof (error as { code: unknown }).code === 'number'
       ? (error as { code: number }).code
       : httpStatus.BAD_REQUEST
+  // APIError.errors is typed unknown[] — pass array Errors verbatim, drop
+  // non-array shapes to undefined rather than casting (the message + the
+  // logged error above retain the diagnostic detail).
   throw new APIError(
     code,
     `${IntuitAPIErrorMessage}${opName}`,
-    error as unknown[] | undefined,
+    Array.isArray(error) ? error : undefined,
   )
 }
 

--- a/src/utils/intuitAPI.ts
+++ b/src/utils/intuitAPI.ts
@@ -560,7 +560,9 @@ export default class IntuitAPI {
     return parsedAccount
   }
 
-  async _createPayment(payload: QBPaymentCreatePayloadType) {
+  async _createPayment(
+    payload: QBPaymentCreatePayloadType,
+  ): Promise<QBPaymentResponseType> {
     CustomLogger.info({
       obj: { payload },
       message: `IntuitAPI#createPayment | payment creation start for realmId: ${this.tokens.intuitRealmId}. `,
@@ -577,11 +579,12 @@ export default class IntuitAPI {
       )
     }
 
+    const parsed = QBPaymentResponseSchema.parse(payment)
     CustomLogger.info({
-      obj: { response: payment.Payment },
-      message: `IntuitAPI#createPayment | payment created with Id = ${payment.Payment?.Id}.`,
+      obj: { response: parsed.Payment },
+      message: `IntuitAPI#createPayment | payment created with Id = ${parsed.Payment.Id}.`,
     })
-    return payment
+    return parsed
   }
 
   async _getInvoice(
@@ -657,7 +660,9 @@ export default class IntuitAPI {
     return parsed
   }
 
-  async _deletePayment(payload: QBDeletePayloadType) {
+  async _deletePayment(
+    payload: QBDeletePayloadType,
+  ): Promise<QBPaymentDeleteResponseType> {
     CustomLogger.info({
       obj: { payload },
       message: `IntuitAPI#deletePayment | payment delete start for realmId: ${this.tokens.intuitRealmId}. `,
@@ -674,11 +679,12 @@ export default class IntuitAPI {
       )
     }
 
+    const parsed = QBPaymentDeleteResponseSchema.parse(payment)
     CustomLogger.info({
-      obj: { response: payment.Payment },
-      message: `IntuitAPI#deletePayment | payment deleted with Id = ${payment.Payment?.Id}. `,
+      obj: { response: parsed.Payment },
+      message: `IntuitAPI#deletePayment | payment deleted with Id = ${parsed.Payment.Id}. `,
     })
-    return payment
+    return parsed
   }
 
   /**
@@ -752,7 +758,9 @@ export default class IntuitAPI {
     return parsed.Account
   }
 
-  async _createPurchase(payload: QBPurchaseCreatePayloadType) {
+  async _createPurchase(
+    payload: QBPurchaseCreatePayloadType,
+  ): Promise<QBPurchaseResponseType> {
     CustomLogger.info({
       obj: { payload },
       message: `IntuitAPI#createPurchase | Purchase create start for realmId: ${this.tokens.intuitRealmId}.`,
@@ -769,14 +777,17 @@ export default class IntuitAPI {
       )
     }
 
+    const parsed = QBPurchaseResponseSchema.parse(purchase)
     CustomLogger.info({
-      obj: { response: purchase.Purchase },
-      message: `IntuitAPI#createPurchase | Purchase created with Id = ${purchase.Purchase?.Id}.`,
+      obj: { response: parsed.Purchase },
+      message: `IntuitAPI#createPurchase | Purchase created with Id = ${parsed.Purchase.Id}.`,
     })
-    return purchase
+    return parsed
   }
 
-  async _deletePurchase(payload: QBDeletePayloadType) {
+  async _deletePurchase(
+    payload: QBDeletePayloadType,
+  ): Promise<QBPurchaseDeleteResponseType> {
     CustomLogger.info({
       obj: { payload },
       message: `IntuitAPI#deletePurchase | purchase delete start for realmId: ${this.tokens.intuitRealmId}.`,
@@ -793,11 +804,12 @@ export default class IntuitAPI {
       )
     }
 
+    const parsed = QBPurchaseDeleteResponseSchema.parse(purchase)
     CustomLogger.info({
-      obj: { response: purchase.Purchase },
-      message: `IntuitAPI#deletePurchase | purchase deleted with Id = ${purchase.Purchase?.Id}. `,
+      obj: { response: parsed.Purchase },
+      message: `IntuitAPI#deletePurchase | purchase deleted with Id = ${parsed.Purchase.Id}. `,
     })
-    return purchase
+    return parsed
   }
 
   async _getCompanyInfo(): Promise<CompanyInfoType['CompanyInfo'][0]> {

--- a/src/utils/intuitAPI.ts
+++ b/src/utils/intuitAPI.ts
@@ -44,10 +44,13 @@ import {
   QBPurchaseDeleteResponseSchema,
   SingleIdAndTokenResponseSchema,
   SingleIdAndTokenResponseType,
+  QBInvoiceQueryResponseSchema,
+  CustomerListEnvelopeSchema,
 } from '@/type/dto/intuitAPI.dto'
 import { escapeForQBQuery, getNameAsCustomer } from '@/utils/string'
 import CustomLogger from '@/utils/logger'
 import httpStatus from 'http-status'
+import { z } from 'zod'
 
 export type IntuitAPITokensType = Pick<
   QBPortalConnectionSelectSchemaType,
@@ -62,6 +65,56 @@ export type IntuitAPITokensType = Pick<
 > & { isSuspended?: boolean }
 
 export const IntuitAPIErrorMessage = '#IntuitAPIErrorMessage#'
+
+type GetACustomerOverloads = {
+  (
+    displayName: string,
+    id?: undefined,
+    includeInactive?: boolean,
+  ): Promise<CustomerQueryResponseType>
+  (
+    displayName: undefined,
+    id: string,
+    includeInactive?: boolean,
+  ): Promise<CustomerQueryResponseType>
+  (
+    displayName: string,
+    id: string,
+    includeInactive?: boolean,
+  ): Promise<CustomerQueryResponseType>
+}
+
+type GetAnItemOverloads = {
+  (
+    name: string,
+    id?: undefined,
+    includeInactive?: boolean,
+  ): Promise<QBItemRowType>
+  (
+    name: undefined,
+    id: string,
+    includeInactive?: boolean,
+  ): Promise<QBItemRowType>
+  (name: string, id: string, includeInactive?: boolean): Promise<QBItemRowType>
+}
+
+type GetAnAccountOverloads = {
+  (
+    accountName: string,
+    id?: undefined,
+    includeInactive?: boolean,
+  ): Promise<QBAccountRowType>
+  (
+    accountName: undefined,
+    id: string,
+    includeInactive?: boolean,
+  ): Promise<QBAccountRowType>
+  (
+    accountName: string,
+    id: string,
+    includeInactive?: boolean,
+  ): Promise<QBAccountRowType>
+}
 
 // Upper bound on the " (Customer) N" suffix counter when resolving a unique
 // DisplayName. If exceeded, creation is aborted and a human is paged — having
@@ -90,7 +143,7 @@ export default class IntuitAPI {
    */
   private async postFetchWithHeaders(
     url: string,
-    body: Record<string, any>,
+    body: unknown,
     customHeaders?: Record<string, string>,
   ) {
     const headers = {
@@ -116,7 +169,7 @@ export default class IntuitAPI {
     return response
   }
 
-  async _customQuery(query: string) {
+  async _customQuery(query: string): Promise<unknown> {
     CustomLogger.info({ message: 'IntuitAPI#customQuery', obj: { query } })
     const url = `${intuitBaseUrl}/v3/company/${this.tokens.intuitRealmId}/query?query=${encodeURIComponent(query)}&minorversion=${intuitApiMinorVersion}`
     const res = await this.getFetchWithHeader(url)
@@ -274,8 +327,9 @@ export default class IntuitAPI {
 
     if (!qbCustomers) return null
 
-    if (!qbCustomers.Customer) return
-    return CustomerQueryResponseSchema.parse(qbCustomers.Customer[0])
+    const envelope = CustomerListEnvelopeSchema.parse(qbCustomers)
+    if (!envelope.Customer) return
+    return CustomerQueryResponseSchema.parse(envelope.Customer[0])
   }
 
   // QBO's parser mishandles special chars on PrimaryEmailAddr filters, so we
@@ -301,10 +355,11 @@ export default class IntuitAPI {
     while (true) {
       const customerQuery = `SELECT Id, SyncToken, Active, CompanyName, PrimaryEmailAddr FROM Customer WHERE Active IN (true, false) ORDERBY Id ASC STARTPOSITION ${startPosition} MAXRESULTS ${pageSize}`
       const qbCustomers = await this.customQuery(customerQuery)
-      const customers = qbCustomers?.Customer ?? []
+      const envelope = CustomerListEnvelopeSchema.parse(qbCustomers ?? {})
+      const customers = envelope.Customer ?? []
       if (customers.length === 0) return
 
-      const match = customers.find((c: CustomerQueryResponseType) => {
+      const match = customers.find((c) => {
         const addr = c.PrimaryEmailAddr?.Address
         if (typeof addr !== 'string') return false
         if (addr.trim().toLowerCase() !== needle) return false
@@ -365,13 +420,30 @@ export default class IntuitAPI {
     // Case-insensitive comparison: QBO's DisplayName equality is case-
     // insensitive, so a returned record may differ in case from our candidate.
     const usedNames = new Set<string>()
-    for (const c of customerRes?.Customer ?? []) {
+    const customerNameEnv = z
+      .object({
+        Customer: z.array(z.object({ DisplayName: z.string() })).optional(),
+      })
+      .parse(customerRes ?? {})
+    for (const c of customerNameEnv.Customer ?? []) {
       usedNames.add(c.DisplayName.toLowerCase())
     }
-    for (const v of vendorRes?.Vendor ?? []) {
+
+    const vendorNameEnv = z
+      .object({
+        Vendor: z.array(z.object({ DisplayName: z.string() })).optional(),
+      })
+      .parse(vendorRes ?? {})
+    for (const v of vendorNameEnv.Vendor ?? []) {
       usedNames.add(v.DisplayName.toLowerCase())
     }
-    for (const e of employeeRes?.Employee ?? []) {
+
+    const employeeNameEnv = z
+      .object({
+        Employee: z.array(z.object({ DisplayName: z.string() })).optional(),
+      })
+      .parse(employeeRes ?? {})
+    for (const e of employeeNameEnv.Employee ?? []) {
       usedNames.add(e.DisplayName.toLowerCase())
     }
 
@@ -447,7 +519,8 @@ export default class IntuitAPI {
 
     if (!qbItems) return null
 
-    return QBItemsResponseSchema.parse(qbItems.Item || [])
+    const envelope = QBItemQueryResponseSchema.parse(qbItems)
+    return QBItemsResponseSchema.parse(envelope.Item || [])
   }
 
   async _invoiceSparseUpdate(
@@ -597,13 +670,20 @@ export default class IntuitAPI {
     const query = `select Id, SyncToken, DocNumber from Invoice where DocNumber = '${escapeForQBQuery(invoiceNumber)}' maxresults 1`
     const invoice = await this.customQuery(query)
 
-    if (!invoice.Invoice) return null
+    if (!invoice)
+      throw new APIError(
+        httpStatus.BAD_REQUEST,
+        'IntuitAPI#getInvoice | message = no response',
+      )
+
+    const envelope = QBInvoiceQueryResponseSchema.parse(invoice)
+    if (!envelope.Invoice || envelope.Invoice.length === 0) return null
 
     CustomLogger.info({
-      obj: { response: invoice.Invoice },
+      obj: { response: envelope.Invoice },
       message: `IntuitAPI#getInvoice | invoice fetched with doc number = ${invoiceNumber}.`,
     })
-    return SingleIdAndTokenResponseSchema.parse(invoice.Invoice[0])
+    return SingleIdAndTokenResponseSchema.parse(envelope.Invoice[0])
   }
 
   async _voidInvoice(
@@ -843,44 +923,16 @@ export default class IntuitAPI {
   createCustomer = this.wrapWithRetry(this._createCustomer)
   createItem = this.wrapWithRetry(this._createItem)
   getSingleIncomeAccount = this._getSingleIncomeAccount.bind(this)
-  getACustomer: {
-    (
-      displayName: string,
-      id?: undefined,
-      includeInactive?: boolean,
-    ): Promise<CustomerQueryResponseType>
-    (
-      displayName: undefined,
-      id: string,
-      includeInactive?: boolean,
-    ): Promise<CustomerQueryResponseType>
-    (
-      displayName: string,
-      id: string,
-      includeInactive?: boolean,
-    ): Promise<CustomerQueryResponseType>
-  } = this._getACustomer.bind(this) as any
-  // Additional rationale beyond the wrap convention: a transient 429 mid-walk
-  // would replay from page 1 and amplify rate-limit pressure (same reasoning
-  // as resolveUniqueCustomerName).
+  getACustomer: GetACustomerOverloads = this._getACustomer.bind(
+    this,
+  ) as unknown as GetACustomerOverloads
+  // Intentionally NOT wrapped in wrapWithRetry — a transient 429 mid-walk would
+  // replay from page 1 and amplify rate-limit pressure. The inner customQuery
+  // calls already retry on 429 (same reasoning as resolveUniqueCustomerName).
   getCustomerByEmail = this._getCustomerByEmail.bind(this)
-  getAnItem: {
-    (
-      name: string,
-      id?: undefined,
-      includeInactive?: boolean,
-    ): Promise<QBItemRowType>
-    (
-      name: undefined,
-      id: string,
-      includeInactive?: boolean,
-    ): Promise<QBItemRowType>
-    (
-      name: string,
-      id: string,
-      includeInactive?: boolean,
-    ): Promise<QBItemRowType>
-  } = this._getAnItem.bind(this) as any
+  getAnItem: GetAnItemOverloads = this._getAnItem.bind(
+    this,
+  ) as unknown as GetAnItemOverloads
   getAllItems = this._getAllItems.bind(this)
   invoiceSparseUpdate = this.wrapWithRetry(this._invoiceSparseUpdate)
   customerSparseUpdate = this.wrapWithRetry(this._customerSparseUpdate)
@@ -889,23 +941,9 @@ export default class IntuitAPI {
   getInvoice = this._getInvoice.bind(this)
   voidInvoice = this.wrapWithRetry(this._voidInvoice)
   deleteInvoice = this.wrapWithRetry(this._deleteInvoice)
-  getAnAccount: {
-    (
-      accountName: string,
-      id?: undefined,
-      includeInactive?: boolean,
-    ): Promise<QBAccountRowType>
-    (
-      accountName: undefined,
-      id: string,
-      includeInactive?: boolean,
-    ): Promise<QBAccountRowType>
-    (
-      accountName: string,
-      id: string,
-      includeInactive?: boolean,
-    ): Promise<QBAccountRowType>
-  } = this._getAnAccount.bind(this) as any
+  getAnAccount: GetAnAccountOverloads = this._getAnAccount.bind(
+    this,
+  ) as unknown as GetAnAccountOverloads
   createAccount = this.wrapWithRetry(this._createAccount)
   updateAccount = this.wrapWithRetry(this._updateAccount)
   createPurchase = this.wrapWithRetry(this._createPurchase)

--- a/src/utils/intuitAPI.ts
+++ b/src/utils/intuitAPI.ts
@@ -268,7 +268,7 @@ export default class IntuitAPI {
     CustomLogger.info({
       message: `IntuitAPI#getSingleIncomeAccount | Income account query start for realmId: ${this.tokens.intuitRealmId}`,
     })
-    const sqlQuery = `SELECT Id FROM Account WHERE AccountType = 'Income' AND AccountSubType = 'SalesOfProductIncome' AND Active = true maxresults 1`
+    const sqlQuery = `SELECT Id, Name, SyncToken, Active FROM Account WHERE AccountType = 'Income' AND AccountSubType = 'SalesOfProductIncome' AND Active = true maxresults 1`
     const qbIncomeAccountRefInfo = await this.customQuery(sqlQuery)
 
     if (!qbIncomeAccountRefInfo)
@@ -504,7 +504,7 @@ export default class IntuitAPI {
 
   async _getAllItems(
     limit: number,
-    columns: string[] = ['Id'],
+    columns: string[],
   ): Promise<QBItemsResponseType | null> {
     CustomLogger.info({
       message: `IntuitAPI#getAllItems | Item query start for realmId: ${this.tokens.intuitRealmId}`,

--- a/src/utils/intuitAPI.ts
+++ b/src/utils/intuitAPI.ts
@@ -15,10 +15,13 @@ import {
   QBPurchaseCreatePayloadType,
   QBDeletePayloadType,
   QBDestructiveInvoicePayloadSchema,
-  QBNameValueSchemaType,
+  QBItemRowType,
+  QBItemQueryResponseSchema,
   QBItemResponseType,
   QBItemResponseSchema,
   QBAccountUpdatePayloadType,
+  QBAccountRowType,
+  QBAccountQueryResponseSchema,
   QBAccountResponseType,
   QBAccountResponseSchema,
   CompanyInfoType,
@@ -26,6 +29,18 @@ import {
   CustomerQueryResponseType,
   CustomerQueryResponseSchema,
   QBItemsResponseSchema,
+  QBInvoiceResponseType,
+  QBInvoiceResponseSchema,
+  QBInvoiceDeleteResponseType,
+  QBInvoiceDeleteResponseSchema,
+  QBPaymentResponseType,
+  QBPaymentResponseSchema,
+  QBPaymentDeleteResponseType,
+  QBPaymentDeleteResponseSchema,
+  QBPurchaseResponseType,
+  QBPurchaseResponseSchema,
+  QBPurchaseDeleteResponseType,
+  QBPurchaseDeleteResponseSchema,
   SingleIdAndTokenResponseSchema,
 } from '@/type/dto/intuitAPI.dto'
 import { escapeForQBQuery, getNameAsCustomer } from '@/utils/string'
@@ -43,22 +58,6 @@ export type IntuitAPITokensType = Pick<
   | 'serviceItemRef'
   | 'clientFeeRef'
 > & { isSuspended?: boolean }
-
-export type BaseResponseType = {
-  Id: string
-  SyncToken: string
-  Active: boolean
-}
-
-export type AccountResponseType = BaseResponseType & {
-  Name: string
-}
-
-export type ItemResponseType = BaseResponseType & {
-  Name: string
-  ClassRef?: QBNameValueSchemaType
-  UnitPrice: number
-}
 
 export const IntuitAPIErrorMessage = '#IntuitAPIErrorMessage#'
 
@@ -386,17 +385,17 @@ export default class IntuitAPI {
     name: string,
     id?: undefined,
     includeInactive?: boolean,
-  ): Promise<ItemResponseType>
+  ): Promise<QBItemRowType>
   async _getAnItem(
     name: undefined,
     id: string,
     includeInactive?: boolean,
-  ): Promise<ItemResponseType>
+  ): Promise<QBItemRowType>
   async _getAnItem(
     name: string,
     id: string,
     includeInactive?: boolean,
-  ): Promise<ItemResponseType>
+  ): Promise<QBItemRowType>
   async _getAnItem(name?: string, id?: string, includeInactive?: boolean) {
     if (!name && !id) {
       throw new APIError(
@@ -665,17 +664,17 @@ export default class IntuitAPI {
     accountName: string,
     id?: undefined,
     includeInactive?: boolean,
-  ): Promise<AccountResponseType>
+  ): Promise<QBAccountRowType>
   async _getAnAccount(
     accountName: undefined,
     id: string,
     includeInactive?: boolean,
-  ): Promise<AccountResponseType>
+  ): Promise<QBAccountRowType>
   async _getAnAccount(
     accountName: string,
     id: string,
     includeInactive?: boolean,
-  ): Promise<AccountResponseType>
+  ): Promise<QBAccountRowType>
   async _getAnAccount(
     accountName?: string,
     id?: string,
@@ -830,17 +829,17 @@ export default class IntuitAPI {
       name: string,
       id?: undefined,
       includeInactive?: boolean,
-    ): Promise<ItemResponseType>
+    ): Promise<QBItemRowType>
     (
       name: undefined,
       id: string,
       includeInactive?: boolean,
-    ): Promise<ItemResponseType>
+    ): Promise<QBItemRowType>
     (
       name: string,
       id: string,
       includeInactive?: boolean,
-    ): Promise<ItemResponseType>
+    ): Promise<QBItemRowType>
   } = this._getAnItem.bind(this) as any
   getAllItems = this._getAllItems.bind(this)
   invoiceSparseUpdate = this.wrapWithRetry(this._invoiceSparseUpdate)
@@ -855,17 +854,17 @@ export default class IntuitAPI {
       accountName: string,
       id?: undefined,
       includeInactive?: boolean,
-    ): Promise<AccountResponseType>
+    ): Promise<QBAccountRowType>
     (
       accountName: undefined,
       id: string,
       includeInactive?: boolean,
-    ): Promise<AccountResponseType>
+    ): Promise<QBAccountRowType>
     (
       accountName: string,
       id: string,
       includeInactive?: boolean,
-    ): Promise<AccountResponseType>
+    ): Promise<QBAccountRowType>
   } = this._getAnAccount.bind(this) as any
   createAccount = this.wrapWithRetry(this._createAccount)
   updateAccount = this.wrapWithRetry(this._updateAccount)

--- a/src/utils/intuitAPI.ts
+++ b/src/utils/intuitAPI.ts
@@ -28,6 +28,7 @@ import {
   CompanyInfoSchema,
   CustomerQueryResponseType,
   CustomerQueryResponseSchema,
+  QBCustomerResponseSchema,
   QBItemsResponseSchema,
   QBItemsResponseType,
   QBInvoiceResponseType,
@@ -46,6 +47,7 @@ import {
   SingleIdAndTokenResponseType,
   QBInvoiceQueryResponseSchema,
   CustomerListEnvelopeSchema,
+  QBFaultSchema,
 } from '@/type/dto/intuitAPI.dto'
 import { escapeForQBQuery, getNameAsCustomer } from '@/utils/string'
 import CustomLogger from '@/utils/logger'
@@ -65,6 +67,30 @@ export type IntuitAPITokensType = Pick<
 > & { isSuspended?: boolean }
 
 export const IntuitAPIErrorMessage = '#IntuitAPIErrorMessage#'
+
+// Throws an APIError if `raw` is a QBO Fault response; no-op otherwise.
+// Replaces the duplicated `if (raw?.Fault) throw ...` block in every method.
+// Fault.Error.code is preserved only when numeric (HTTP-safe); QBO's
+// string codes fall back to BAD_REQUEST as before.
+export function assertNotQBFault(raw: unknown, opName: string): void {
+  const result = QBFaultSchema.safeParse(raw)
+  if (!result.success) return
+  const error = result.data.Fault.Error
+  CustomLogger.error({ obj: error, message: 'Error: ' })
+  const code =
+    error &&
+    typeof error === 'object' &&
+    !Array.isArray(error) &&
+    'code' in error &&
+    typeof (error as { code: unknown }).code === 'number'
+      ? (error as { code: number }).code
+      : httpStatus.BAD_REQUEST
+  throw new APIError(
+    code,
+    `${IntuitAPIErrorMessage}${opName}`,
+    error as unknown[] | undefined,
+  )
+}
 
 type GetACustomerOverloads = {
   (
@@ -143,9 +169,9 @@ export default class IntuitAPI {
    */
   private async postFetchWithHeaders(
     url: string,
-    body: unknown,
+    body: Record<string, unknown>,
     customHeaders?: Record<string, string>,
-  ) {
+  ): Promise<unknown> {
     const headers = {
       ...this.headers,
       ...customHeaders,
@@ -160,7 +186,7 @@ export default class IntuitAPI {
   private async getFetchWithHeader(
     url: string,
     customHeaders?: Record<string, string>,
-  ) {
+  ): Promise<unknown> {
     const headers = {
       ...this.headers,
       ...customHeaders,
@@ -174,15 +200,14 @@ export default class IntuitAPI {
     const url = `${intuitBaseUrl}/v3/company/${this.tokens.intuitRealmId}/query?query=${encodeURIComponent(query)}&minorversion=${intuitApiMinorVersion}`
     const res = await this.getFetchWithHeader(url)
 
-    if (res?.Fault) {
-      CustomLogger.error({ obj: res.Fault?.Error, message: 'Error: ' })
+    if (!res)
       throw new APIError(
-        res.Fault.Error?.code || httpStatus.BAD_REQUEST,
-        `${IntuitAPIErrorMessage}customQuery`,
-        res.Fault?.Error,
+        httpStatus.BAD_REQUEST,
+        'IntuitAPI#customQuery | message = no response',
       )
-    }
-    return res.QueryResponse
+
+    assertNotQBFault(res, 'customQuery')
+    return (res as { QueryResponse?: unknown }).QueryResponse
   }
 
   async _createInvoice(
@@ -195,14 +220,13 @@ export default class IntuitAPI {
     const url = `${intuitBaseUrl}/v3/company/${this.tokens.intuitRealmId}/invoice?minorversion=${intuitApiMinorVersion}`
     const invoice = await this.postFetchWithHeaders(url, payload)
 
-    if (invoice?.Fault) {
-      CustomLogger.error({ obj: invoice.Fault?.Error, message: 'Error: ' })
+    if (!invoice)
       throw new APIError(
-        invoice.Fault?.Error?.code || httpStatus.BAD_REQUEST,
-        `${IntuitAPIErrorMessage}createInvoice`,
-        invoice.Fault?.Error,
+        httpStatus.BAD_REQUEST,
+        'IntuitAPI#createInvoice | message = no response',
       )
-    }
+
+    assertNotQBFault(invoice, 'createInvoice')
 
     const parsed = QBInvoiceResponseSchema.parse(invoice)
     CustomLogger.info({
@@ -222,21 +246,20 @@ export default class IntuitAPI {
     const url = `${intuitBaseUrl}/v3/company/${this.tokens.intuitRealmId}/customer?minorversion=${intuitApiMinorVersion}`
     const customer = await this.postFetchWithHeaders(url, payload)
 
-    if (customer?.Fault) {
-      CustomLogger.error({ obj: customer.Fault?.Error, message: 'Error: ' })
+    if (!customer)
       throw new APIError(
-        customer.Fault?.Error?.code || httpStatus.BAD_REQUEST,
-        `${IntuitAPIErrorMessage}createCustomer`,
-        customer.Fault?.Error,
+        httpStatus.BAD_REQUEST,
+        'IntuitAPI#createCustomer | message = no response',
       )
-    }
 
-    const parsedCustomer = CustomerQueryResponseSchema.parse(customer.Customer)
+    assertNotQBFault(customer, 'createCustomer')
+
+    const parsed = QBCustomerResponseSchema.parse(customer)
     CustomLogger.info({
-      obj: { response: parsedCustomer },
-      message: `IntuitAPI#createCustomer | customer created with name = ${parsedCustomer.FullyQualifiedName ?? ''}.`,
+      obj: { response: parsed.Customer },
+      message: `IntuitAPI#createCustomer | customer created with name = ${parsed.Customer.FullyQualifiedName ?? ''}.`,
     })
-    return parsedCustomer
+    return parsed.Customer
   }
 
   async _createItem(payload: QBItemCreatePayloadType): Promise<QBItemRowType> {
@@ -247,14 +270,13 @@ export default class IntuitAPI {
     const url = `${intuitBaseUrl}/v3/company/${this.tokens.intuitRealmId}/item?minorversion=${intuitApiMinorVersion}`
     const item = await this.postFetchWithHeaders(url, payload)
 
-    if (item?.Fault) {
-      CustomLogger.error({ obj: item.Fault?.Error, message: 'Error: ' })
+    if (!item)
       throw new APIError(
-        item.Fault?.Error?.code || httpStatus.BAD_REQUEST,
-        `${IntuitAPIErrorMessage}createItem`,
-        item.Fault?.Error,
+        httpStatus.BAD_REQUEST,
+        'IntuitAPI#createItem | message = no response',
       )
-    }
+
+    assertNotQBFault(item, 'createItem')
 
     const parsed = QBItemResponseSchema.parse(item)
     CustomLogger.info({
@@ -329,7 +351,7 @@ export default class IntuitAPI {
 
     const envelope = CustomerListEnvelopeSchema.parse(qbCustomers)
     if (!envelope.Customer) return
-    return CustomerQueryResponseSchema.parse(envelope.Customer[0])
+    return envelope.Customer[0]
   }
 
   // QBO's parser mishandles special chars on PrimaryEmailAddr filters, so we
@@ -366,7 +388,7 @@ export default class IntuitAPI {
         if ((c.CompanyName || undefined) !== sanitizedCompanyName) return false
         return true
       })
-      if (match) return CustomerQueryResponseSchema.parse(match)
+      if (match) return match
 
       if (customers.length < pageSize) return
       startPosition += pageSize
@@ -502,6 +524,9 @@ export default class IntuitAPI {
     return parsed.Item?.[0] ?? null
   }
 
+  // `columns` MUST include at minimum Id, Name, UnitPrice, SyncToken — the
+  // double-parse path (QBItemQueryResponseSchema then QBItemsResponseSchema)
+  // requires them. Description is optional but typically included by callers.
   async _getAllItems(
     limit: number,
     columns: string[],
@@ -533,14 +558,13 @@ export default class IntuitAPI {
     const url = `${intuitBaseUrl}/v3/company/${this.tokens.intuitRealmId}/invoice?minorversion=${intuitApiMinorVersion}`
     const invoice = await this.postFetchWithHeaders(url, payload)
 
-    if (invoice?.Fault) {
-      CustomLogger.error({ obj: invoice.Fault?.Error, message: 'Error: ' })
+    if (!invoice)
       throw new APIError(
-        invoice.Fault?.Error?.code || httpStatus.BAD_REQUEST,
-        `${IntuitAPIErrorMessage}invoiceSparseUpdate`,
-        invoice.Fault?.Error,
+        httpStatus.BAD_REQUEST,
+        'IntuitAPI#InvoiceSparseUpdate | message = no response',
       )
-    }
+
+    assertNotQBFault(invoice, 'invoiceSparseUpdate')
 
     const parsed = QBInvoiceResponseSchema.parse(invoice)
     CustomLogger.info({
@@ -560,21 +584,20 @@ export default class IntuitAPI {
     const url = `${intuitBaseUrl}/v3/company/${this.tokens.intuitRealmId}/customer?minorversion=${intuitApiMinorVersion}`
     const customer = await this.postFetchWithHeaders(url, payload)
 
-    if (customer?.Fault) {
-      CustomLogger.error({ obj: customer.Fault?.Error, message: 'Error: ' })
+    if (!customer)
       throw new APIError(
-        customer.Fault?.Error?.code || httpStatus.BAD_REQUEST,
-        `${IntuitAPIErrorMessage}customerSparseUpdate`,
-        customer.Fault?.Error,
+        httpStatus.BAD_REQUEST,
+        'IntuitAPI#customerSparseUpdate | message = no response',
       )
-    }
 
-    const parsedCustomer = CustomerQueryResponseSchema.parse(customer.Customer)
+    assertNotQBFault(customer, 'customerSparseUpdate')
+
+    const parsed = QBCustomerResponseSchema.parse(customer)
     CustomLogger.info({
-      obj: { response: parsedCustomer },
-      message: `IntuitAPI#customerSparseUpdate | customer sparse updated with name = ${parsedCustomer.FullyQualifiedName ?? ''}. `,
+      obj: { response: parsed.Customer },
+      message: `IntuitAPI#customerSparseUpdate | customer sparse updated with name = ${parsed.Customer.FullyQualifiedName ?? ''}. `,
     })
-    return parsedCustomer
+    return parsed.Customer
   }
 
   async _itemFullUpdate(
@@ -587,20 +610,19 @@ export default class IntuitAPI {
     const url = `${intuitBaseUrl}/v3/company/${this.tokens.intuitRealmId}/item?minorversion=${intuitApiMinorVersion}`
     const item = await this.postFetchWithHeaders(url, payload)
 
-    if (item?.Fault) {
-      CustomLogger.error({ obj: item.Fault?.Error, message: 'Error: ' })
+    if (!item)
       throw new APIError(
-        item.Fault?.Error?.code || httpStatus.BAD_REQUEST,
-        `${IntuitAPIErrorMessage}itemFullUpdate`,
-        item.Fault?.Error,
+        httpStatus.BAD_REQUEST,
+        'IntuitAPI#itemFullUpdate | message = no response',
       )
-    }
+
+    assertNotQBFault(item, 'itemFullUpdate')
 
     const parsedItem = QBItemResponseSchema.parse(item)
 
     CustomLogger.info({
-      obj: { response: item.Item },
-      message: `IntuitAPI#itemFullUpdate | item full updated with Id = ${item.Item?.Id}.`,
+      obj: { response: parsedItem.Item },
+      message: `IntuitAPI#itemFullUpdate | item full updated with Id = ${parsedItem.Item.Id}.`,
     })
     return parsedItem
   }
@@ -615,14 +637,13 @@ export default class IntuitAPI {
     const url = `${intuitBaseUrl}/v3/company/${this.tokens.intuitRealmId}/account?minorversion=${intuitApiMinorVersion}`
     const account = await this.postFetchWithHeaders(url, payload)
 
-    if (account?.Fault) {
-      CustomLogger.error({ obj: account.Fault?.Error, message: 'Error: ' })
+    if (!account)
       throw new APIError(
         httpStatus.BAD_REQUEST,
-        `${IntuitAPIErrorMessage}updateAccount`,
-        account.Fault?.Error,
+        'IntuitAPI#updateAccount | message = no response',
       )
-    }
+
+    assertNotQBFault(account, 'updateAccount')
 
     const parsedAccount = QBAccountResponseSchema.parse(account)
 
@@ -643,14 +664,13 @@ export default class IntuitAPI {
     const url = `${intuitBaseUrl}/v3/company/${this.tokens.intuitRealmId}/payment?minorversion=${intuitApiMinorVersion}`
     const payment = await this.postFetchWithHeaders(url, payload)
 
-    if (payment?.Fault) {
-      CustomLogger.error({ obj: payment.Fault?.Error, message: 'Error: ' })
+    if (!payment)
       throw new APIError(
-        payment.Fault?.Error?.code || httpStatus.BAD_REQUEST,
-        `${IntuitAPIErrorMessage}createPayment`,
-        payment.Fault?.Error,
+        httpStatus.BAD_REQUEST,
+        'IntuitAPI#createPayment | message = no response',
       )
-    }
+
+    assertNotQBFault(payment, 'createPayment')
 
     const parsed = QBPaymentResponseSchema.parse(payment)
     CustomLogger.info({
@@ -696,14 +716,13 @@ export default class IntuitAPI {
     const url = `${intuitBaseUrl}/v3/company/${this.tokens.intuitRealmId}/invoice?operation=void&minorversion=${intuitApiMinorVersion}`
     const invoice = await this.postFetchWithHeaders(url, payload)
 
-    if (invoice?.Fault) {
-      CustomLogger.error({ obj: invoice.Fault?.Error, message: 'Error: ' })
+    if (!invoice)
       throw new APIError(
-        invoice.Fault?.Error?.code || httpStatus.BAD_REQUEST,
-        `${IntuitAPIErrorMessage}voidInvoice`,
-        invoice.Fault?.Error,
+        httpStatus.BAD_REQUEST,
+        'IntuitAPI#voidInvoice | message = no response',
       )
-    }
+
+    assertNotQBFault(invoice, 'voidInvoice')
 
     const parsed = QBInvoiceResponseSchema.parse(invoice)
     CustomLogger.info({
@@ -723,14 +742,14 @@ export default class IntuitAPI {
     const url = `${intuitBaseUrl}/v3/company/${this.tokens.intuitRealmId}/invoice?operation=delete&minorversion=${intuitApiMinorVersion}`
     const invoice = await this.postFetchWithHeaders(url, payload)
 
-    if (invoice?.Fault) {
-      CustomLogger.error({ obj: invoice.Fault?.Error, message: 'Error: ' })
+    if (!invoice) {
       throw new APIError(
-        invoice.Fault?.Error?.code || httpStatus.BAD_REQUEST,
-        `${IntuitAPIErrorMessage}deleteInvoice`,
-        invoice.Fault?.Error,
+        httpStatus.BAD_REQUEST,
+        'IntuitAPI#deleteInvoice | No invoice deletion confirmation was received from Quickbooks API',
       )
     }
+
+    assertNotQBFault(invoice, 'deleteInvoice')
 
     const parsed = QBInvoiceDeleteResponseSchema.parse(invoice)
     CustomLogger.info({
@@ -750,14 +769,13 @@ export default class IntuitAPI {
     const url = `${intuitBaseUrl}/v3/company/${this.tokens.intuitRealmId}/payment?operation=delete&minorversion=${intuitApiMinorVersion}`
     const payment = await this.postFetchWithHeaders(url, payload)
 
-    if (payment?.Fault) {
-      CustomLogger.error({ obj: payment.Fault?.Error, message: 'Error: ' })
+    if (!payment)
       throw new APIError(
-        payment.Fault?.Error?.code || httpStatus.BAD_REQUEST,
-        `${IntuitAPIErrorMessage}deletePayment`,
-        payment.Fault?.Error,
+        httpStatus.BAD_REQUEST,
+        'IntuitAPI#deletePayment | message = no response',
       )
-    }
+
+    assertNotQBFault(payment, 'deletePayment')
 
     const parsed = QBPaymentDeleteResponseSchema.parse(payment)
     CustomLogger.info({
@@ -821,14 +839,13 @@ export default class IntuitAPI {
     const url = `${intuitBaseUrl}/v3/company/${this.tokens.intuitRealmId}/account?minorversion=${intuitApiMinorVersion}`
     const account = await this.postFetchWithHeaders(url, payload)
 
-    if (account?.Fault) {
-      CustomLogger.error({ obj: account.Fault?.Error, message: 'Error: ' })
+    if (!account)
       throw new APIError(
-        account.Fault?.Error?.code || httpStatus.BAD_REQUEST,
-        `${IntuitAPIErrorMessage}createAccount`,
-        account.Fault?.Error,
+        httpStatus.BAD_REQUEST,
+        'IntuitAPI#createAccount | message = no response',
       )
-    }
+
+    assertNotQBFault(account, 'createAccount')
 
     const parsed = QBAccountResponseSchema.parse(account)
     CustomLogger.info({
@@ -848,14 +865,13 @@ export default class IntuitAPI {
     const url = `${intuitBaseUrl}/v3/company/${this.tokens.intuitRealmId}/purchase?minorversion=${intuitApiMinorVersion}`
     const purchase = await this.postFetchWithHeaders(url, payload)
 
-    if (purchase?.Fault) {
-      CustomLogger.error({ obj: purchase.Fault?.Error, message: 'Error: ' })
+    if (!purchase)
       throw new APIError(
-        purchase.Fault?.Error?.code || httpStatus.BAD_REQUEST,
-        `${IntuitAPIErrorMessage}createPurchase`,
-        purchase.Fault?.Error,
+        httpStatus.BAD_REQUEST,
+        'IntuitAPI#createPurchase | message = no response',
       )
-    }
+
+    assertNotQBFault(purchase, 'createPurchase')
 
     const parsed = QBPurchaseResponseSchema.parse(purchase)
     CustomLogger.info({
@@ -875,14 +891,13 @@ export default class IntuitAPI {
     const url = `${intuitBaseUrl}/v3/company/${this.tokens.intuitRealmId}/purchase?operation=delete&minorversion=${intuitApiMinorVersion}`
     const purchase = await this.postFetchWithHeaders(url, payload)
 
-    if (purchase?.Fault) {
-      CustomLogger.error({ obj: purchase.Fault?.Error, message: 'Error: ' })
+    if (!purchase)
       throw new APIError(
-        purchase.Fault?.Error?.code || httpStatus.BAD_REQUEST,
-        `${IntuitAPIErrorMessage}deletePurchase`,
-        purchase.Fault?.Error,
+        httpStatus.BAD_REQUEST,
+        'IntuitAPI#deletePurchase | message = no response',
       )
-    }
+
+    assertNotQBFault(purchase, 'deletePurchase')
 
     const parsed = QBPurchaseDeleteResponseSchema.parse(purchase)
     CustomLogger.info({

--- a/src/utils/intuitAPI.ts
+++ b/src/utils/intuitAPI.ts
@@ -206,7 +206,7 @@ export default class IntuitAPI {
     return parsed.Item
   }
 
-  async _getSingleIncomeAccount() {
+  async _getSingleIncomeAccount(): Promise<QBAccountRowType | undefined> {
     CustomLogger.info({
       message: `IntuitAPI#getSingleIncomeAccount | Income account query start for realmId: ${this.tokens.intuitRealmId}`,
     })
@@ -219,7 +219,8 @@ export default class IntuitAPI {
         'IntuitAPI#getSingleIncomeAccount | Income account not found',
       )
 
-    return qbIncomeAccountRefInfo.Account?.[0]
+    const parsed = QBAccountQueryResponseSchema.parse(qbIncomeAccountRefInfo)
+    return parsed.Account?.[0]
   }
 
   /**
@@ -699,14 +700,17 @@ export default class IntuitAPI {
     queryCondition = `${queryCondition} AND Active IN (true${includeInactive ? ', false' : ''})` // By default, QB returns only active items.
 
     const query = `SELECT Id, SyncToken, Active, Name FROM Account where ${queryCondition}`
-    const customQuery = await this.customQuery(query)
+    const customQueryRes = await this.customQuery(query)
 
-    if (!customQuery) return null
+    if (!customQueryRes) return null
 
-    return customQuery.Account?.[0]
+    const parsed = QBAccountQueryResponseSchema.parse(customQueryRes)
+    return parsed.Account?.[0] ?? null
   }
 
-  async _createAccount(payload: QBAccountCreatePayloadType) {
+  async _createAccount(
+    payload: QBAccountCreatePayloadType,
+  ): Promise<QBAccountRowType> {
     CustomLogger.info({
       obj: { payload },
       message: `IntuitAPI#createAccount | Account create start for realmId: ${this.tokens.intuitRealmId}. `,
@@ -723,11 +727,12 @@ export default class IntuitAPI {
       )
     }
 
+    const parsed = QBAccountResponseSchema.parse(account)
     CustomLogger.info({
-      obj: { response: account.Account },
-      message: `IntuitAPI#createAccount | Account created with Id = ${account.Account?.Id}. `,
+      obj: { response: parsed.Account },
+      message: `IntuitAPI#createAccount | Account created with Id = ${parsed.Account?.Id}. `,
     })
-    return account.Account
+    return parsed.Account
   }
 
   async _createPurchase(payload: QBPurchaseCreatePayloadType) {

--- a/src/utils/intuitAPI.ts
+++ b/src/utils/intuitAPI.ts
@@ -527,18 +527,13 @@ export default class IntuitAPI {
     return parsed.Item?.[0] ?? null
   }
 
-  // `columns` MUST include at minimum Id, Name, UnitPrice, SyncToken — the
-  // double-parse path (QBItemQueryResponseSchema then QBItemsResponseSchema)
-  // requires them. Description is optional but typically included by callers.
-  async _getAllItems(
-    limit: number,
-    columns: string[],
-  ): Promise<QBItemsResponseType | null> {
+  async _getAllItems(limit: number): Promise<QBItemsResponseType | null> {
     CustomLogger.info({
       message: `IntuitAPI#getAllItems | Item query start for realmId: ${this.tokens.intuitRealmId}`,
     })
-    const stringColumns = columns.map((column) => `${column}`).join(',')
-    const customerQuery = `select ${stringColumns} from Item where Type = 'Service' maxresults ${limit}` // Only get service items
+    // Columns are fixed to match QBItemsResponseSchema; callers don't need
+    // to know the projection. Service items only.
+    const customerQuery = `select Id, Name, UnitPrice, Description, SyncToken from Item where Type = 'Service' maxresults ${limit}`
     CustomLogger.info({
       obj: { customerQuery },
       message: 'IntuitAPI#getAllItems',

--- a/test/unit/utils/intuitAPI.responses.test.ts
+++ b/test/unit/utils/intuitAPI.responses.test.ts
@@ -63,7 +63,12 @@ describe('IntuitAPI customQuery-based reads', () => {
     vi.mocked(getFetcher).mockResolvedValue(
       queryResponse({
         Account: [
-          { Id: '42', Name: 'Sales of Product Income', SyncToken: '0', Active: true },
+          {
+            Id: '42',
+            Name: 'Sales of Product Income',
+            SyncToken: '0',
+            Active: true,
+          },
         ],
       }),
     )

--- a/test/unit/utils/intuitAPI.responses.test.ts
+++ b/test/unit/utils/intuitAPI.responses.test.ts
@@ -1,0 +1,391 @@
+// Exercises the production .parse paths against canonical QBO response
+// shapes. Integration tests mock @/utils/intuitAPI wholesale, so these
+// schemas otherwise never run against realistic input in CI.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@sentry/nextjs', () => ({
+  withScope: vi.fn(),
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+}))
+
+vi.mock('@/utils/logger', () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('@/helper/fetch.helper', () => ({
+  getFetcher: vi.fn(),
+  postFetcher: vi.fn(),
+}))
+
+import IntuitAPI, { IntuitAPITokensType } from '@/utils/intuitAPI'
+import { getFetcher, postFetcher } from '@/helper/fetch.helper'
+import APIError from '@/app/api/core/exceptions/api'
+
+const baseTokens: IntuitAPITokensType = {
+  accessToken: 'access',
+  refreshToken: 'refresh',
+  intuitRealmId: 'realm-1',
+  incomeAccountRef: 'income',
+  expenseAccountRef: 'expense',
+  assetAccountRef: 'asset',
+  serviceItemRef: 'service',
+  clientFeeRef: 'client-fee',
+}
+
+function makeApi() {
+  return new IntuitAPI(baseTokens)
+}
+
+function queryResponse(body: Record<string, unknown>) {
+  return { QueryResponse: body }
+}
+
+function faultResponse() {
+  return {
+    Fault: {
+      Error: [{ Message: 'Bad request', Detail: 'detail', code: '6000' }],
+    },
+  }
+}
+
+describe('IntuitAPI customQuery-based reads', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('getSingleIncomeAccount parses the SQL it actually issues (Id + Name + SyncToken + Active)', async () => {
+    // Regression guard: SQL projection must satisfy QBAccountRowSchema.
+    vi.mocked(getFetcher).mockResolvedValue(
+      queryResponse({
+        Account: [
+          { Id: '42', Name: 'Sales of Product Income', SyncToken: '0', Active: true },
+        ],
+      }),
+    )
+
+    const api = makeApi()
+    const result = await api.getSingleIncomeAccount()
+
+    expect(result).toEqual({
+      Id: '42',
+      Name: 'Sales of Product Income',
+      SyncToken: '0',
+      Active: true,
+    })
+  })
+
+  it('getSingleIncomeAccount throws APIError on Fault response', async () => {
+    vi.mocked(getFetcher).mockResolvedValue(faultResponse())
+
+    const api = makeApi()
+    await expect(api.getSingleIncomeAccount()).rejects.toBeInstanceOf(APIError)
+  })
+
+  it('getAllItems parses rows from a caller-supplied column projection that omits Active', async () => {
+    // Regression guard: mirrors backfillProductInfo's column list (no Active).
+    vi.mocked(getFetcher).mockResolvedValue(
+      queryResponse({
+        Item: [
+          {
+            Id: '1',
+            Name: 'Service A',
+            UnitPrice: 100,
+            Description: 'desc',
+            SyncToken: '0',
+          },
+          {
+            Id: '2',
+            Name: 'Service B',
+            UnitPrice: 200,
+            Description: null,
+            SyncToken: '0',
+          },
+        ],
+      }),
+    )
+
+    const api = makeApi()
+    const result = await api.getAllItems(100, [
+      'Id',
+      'Name',
+      'UnitPrice',
+      'Description',
+      'SyncToken',
+    ])
+
+    expect(result).toHaveLength(2)
+    expect(result?.[0]).toEqual({
+      Id: '1',
+      Name: 'Service A',
+      UnitPrice: 100,
+      Description: 'desc',
+      SyncToken: '0',
+    })
+  })
+
+  it('getAllItems returns parsed empty array when QBO omits the Item key', async () => {
+    vi.mocked(getFetcher).mockResolvedValue(queryResponse({}))
+
+    const api = makeApi()
+    const result = await api.getAllItems(100, [
+      'Id',
+      'Name',
+      'UnitPrice',
+      'SyncToken',
+    ])
+
+    expect(result).toEqual([])
+  })
+
+  it('getAnAccount parses a single-row account match', async () => {
+    vi.mocked(getFetcher).mockResolvedValue(
+      queryResponse({
+        Account: [{ Id: '7', Name: 'Assets', SyncToken: '0', Active: true }],
+      }),
+    )
+
+    const api = makeApi()
+    const result = await api.getAnAccount('Assets')
+
+    expect(result?.Id).toBe('7')
+    expect(result?.SyncToken).toBe('0')
+  })
+
+  it('getAnAccount returns null when no Account key is present', async () => {
+    vi.mocked(getFetcher).mockResolvedValue(queryResponse({}))
+
+    const api = makeApi()
+    const result = await api.getAnAccount('NoSuchAccount')
+
+    expect(result).toBeNull()
+  })
+
+  it('getAnItem parses a single-row item match with the SQL columns it projects', async () => {
+    vi.mocked(getFetcher).mockResolvedValue(
+      queryResponse({
+        Item: [
+          {
+            Id: '9',
+            SyncToken: '0',
+            ClassRef: { name: 'cls', value: 'c1' },
+            Active: true,
+            Name: 'Widget',
+            UnitPrice: 50,
+          },
+        ],
+      }),
+    )
+
+    const api = makeApi()
+    const result = await api.getAnItem('Widget')
+
+    expect(result?.Id).toBe('9')
+    expect(result?.Name).toBe('Widget')
+    expect(result?.UnitPrice).toBe(50)
+  })
+
+  it('getInvoice parses an invoice match and reduces to Id+SyncToken', async () => {
+    vi.mocked(getFetcher).mockResolvedValue(
+      queryResponse({
+        Invoice: [{ Id: '100', SyncToken: '0', DocNumber: 'INV-1' }],
+      }),
+    )
+
+    const api = makeApi()
+    const result = await api.getInvoice('INV-1')
+
+    expect(result).toEqual({ Id: '100', SyncToken: '0' })
+  })
+
+  it('getInvoice returns null when QBO returns an empty Invoice array', async () => {
+    vi.mocked(getFetcher).mockResolvedValue(queryResponse({ Invoice: [] }))
+
+    const api = makeApi()
+    const result = await api.getInvoice('INV-MISSING')
+
+    expect(result).toBeNull()
+  })
+
+  it('getCompanyInfo tolerates a CompanyInfo row without Country', async () => {
+    vi.mocked(getFetcher).mockResolvedValue(
+      queryResponse({ CompanyInfo: [{}] }),
+    )
+
+    const api = makeApi()
+    const result = await api.getCompanyInfo()
+
+    expect(result.Country).toBeUndefined()
+  })
+
+  it('getCompanyInfo passes Country through when present', async () => {
+    vi.mocked(getFetcher).mockResolvedValue(
+      queryResponse({ CompanyInfo: [{ Country: 'US' }] }),
+    )
+
+    const api = makeApi()
+    const result = await api.getCompanyInfo()
+
+    expect(result.Country).toBe('US')
+  })
+
+  it('getACustomer parses a single-row customer match', async () => {
+    vi.mocked(getFetcher).mockResolvedValue(
+      queryResponse({
+        Customer: [
+          {
+            Id: '5',
+            SyncToken: '0',
+            Active: true,
+            CompanyName: 'Acme',
+            PrimaryEmailAddr: { Address: 'a@b.com' },
+          },
+        ],
+      }),
+    )
+
+    const api = makeApi()
+    const result = await api.getACustomer('Acme')
+
+    expect(result?.Id).toBe('5')
+    expect(result?.PrimaryEmailAddr?.Address).toBe('a@b.com')
+  })
+})
+
+describe('IntuitAPI POST-based writes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('createInvoice parses the envelope and returns the full response', async () => {
+    vi.mocked(postFetcher).mockResolvedValue({
+      Invoice: {
+        Id: '500',
+        SyncToken: '0',
+        DocNumber: 'INV-500',
+        TotalAmt: 100,
+      },
+    })
+
+    const api = makeApi()
+    const result = await api.createInvoice({
+      Line: [],
+      CustomerRef: { value: 'c1' },
+    })
+
+    expect(result.Invoice.Id).toBe('500')
+    expect(result.Invoice.SyncToken).toBe('0')
+  })
+
+  it('createInvoice throws APIError on Fault', async () => {
+    vi.mocked(postFetcher).mockResolvedValue(faultResponse())
+
+    const api = makeApi()
+    await expect(
+      api.createInvoice({ Line: [], CustomerRef: { value: 'c1' } }),
+    ).rejects.toBeInstanceOf(APIError)
+  })
+
+  it('createCustomer parses the envelope and returns the inner Customer', async () => {
+    vi.mocked(postFetcher).mockResolvedValue({
+      Customer: {
+        Id: '50',
+        SyncToken: '0',
+        Active: true,
+        FullyQualifiedName: 'Acme',
+      },
+    })
+
+    const api = makeApi()
+    const result = await api.createCustomer({
+      PrimaryEmailAddr: { Address: 'a@b.com' },
+    })
+
+    expect(result.Id).toBe('50')
+    expect(result.FullyQualifiedName).toBe('Acme')
+  })
+
+  it('createItem parses the envelope and returns the inner Item', async () => {
+    vi.mocked(postFetcher).mockResolvedValue({
+      Item: {
+        Id: '200',
+        SyncToken: '0',
+        Name: 'Widget',
+        Active: true,
+        UnitPrice: 25,
+      },
+    })
+
+    const api = makeApi()
+    const result = await api.createItem({
+      Name: 'Widget',
+      UnitPrice: 25,
+      Type: 'Service' as never,
+      Taxable: false,
+    })
+
+    expect(result.Id).toBe('200')
+    expect(result.UnitPrice).toBe(25)
+  })
+
+  it('createAccount parses the envelope and returns the inner Account', async () => {
+    vi.mocked(postFetcher).mockResolvedValue({
+      Account: { Id: '300', Name: 'New Asset', SyncToken: '0', Active: true },
+    })
+
+    const api = makeApi()
+    const result = await api.createAccount({
+      Name: 'New Asset',
+      AccountType: 'Asset',
+      Active: true,
+      Classification: 'Asset',
+    })
+
+    expect(result.Id).toBe('300')
+    expect(result.Name).toBe('New Asset')
+  })
+
+  it('createPayment parses the envelope and returns the full response', async () => {
+    vi.mocked(postFetcher).mockResolvedValue({
+      Payment: { Id: '400', SyncToken: '0', TotalAmt: 100 },
+    })
+
+    const api = makeApi()
+    const result = await api.createPayment({
+      TotalAmt: 100,
+      CustomerRef: { value: 'c1' },
+      Line: [],
+    })
+
+    expect(result.Payment.Id).toBe('400')
+    expect(result.Payment.SyncToken).toBe('0')
+  })
+
+  it('voidInvoice parses the envelope returned by void operation', async () => {
+    vi.mocked(postFetcher).mockResolvedValue({
+      Invoice: { Id: '500', SyncToken: '1', DocNumber: 'INV-500' },
+    })
+
+    const api = makeApi()
+    const result = await api.voidInvoice({ Id: '500', SyncToken: '0' })
+
+    expect(result.Invoice.Id).toBe('500')
+    expect(result.Invoice.SyncToken).toBe('1')
+  })
+
+  it('deleteInvoice parses the deletion-confirmation envelope (no full row)', async () => {
+    vi.mocked(postFetcher).mockResolvedValue({
+      Invoice: { Id: '500', status: 'Deleted', domain: 'QBO' },
+    })
+
+    const api = makeApi()
+    const result = await api.deleteInvoice({ Id: '500', SyncToken: '0' })
+
+    expect(result.Invoice.Id).toBe('500')
+    expect(result.Invoice.status).toBe('Deleted')
+  })
+})

--- a/test/unit/utils/intuitAPI.responses.test.ts
+++ b/test/unit/utils/intuitAPI.responses.test.ts
@@ -91,8 +91,7 @@ describe('IntuitAPI customQuery-based reads', () => {
     await expect(api.getSingleIncomeAccount()).rejects.toBeInstanceOf(APIError)
   })
 
-  it('getAllItems parses rows from a caller-supplied column projection that omits Active', async () => {
-    // Regression guard: mirrors backfillProductInfo's column list (no Active).
+  it('getAllItems parses rows including null Description (QBO returns null for empty)', async () => {
     vi.mocked(getFetcher).mockResolvedValue(
       queryResponse({
         Item: [
@@ -115,13 +114,7 @@ describe('IntuitAPI customQuery-based reads', () => {
     )
 
     const api = makeApi()
-    const result = await api.getAllItems(100, [
-      'Id',
-      'Name',
-      'UnitPrice',
-      'Description',
-      'SyncToken',
-    ])
+    const result = await api.getAllItems(100)
 
     expect(result).toHaveLength(2)
     expect(result?.[0]).toEqual({
@@ -137,12 +130,7 @@ describe('IntuitAPI customQuery-based reads', () => {
     vi.mocked(getFetcher).mockResolvedValue(queryResponse({}))
 
     const api = makeApi()
-    const result = await api.getAllItems(100, [
-      'Id',
-      'Name',
-      'UnitPrice',
-      'SyncToken',
-    ])
+    const result = await api.getAllItems(100)
 
     expect(result).toEqual([])
   })

--- a/test/unit/utils/intuitAPI.test.ts
+++ b/test/unit/utils/intuitAPI.test.ts
@@ -13,9 +13,8 @@
  *     pages followed by empty (off-by-one guard), and on first match.
  *   - Match is case-insensitive and whitespace-tolerant on both sides
  *     (search input AND stored value).
- *   - Malformed `PrimaryEmailAddr` rows do not throw — guards the
- *     defensive `typeof addr === 'string'` predicate that fixed the
- *     type-laundering bug found in review.
+ *   - Rows missing `PrimaryEmailAddr` do not throw — the predicate
+ *     short-circuits on the optional key.
  *   - Empty/whitespace email short-circuits without calling QBO.
  */
 
@@ -56,12 +55,11 @@ const baseTokens: IntuitAPITokensType = {
 }
 
 // Builds a customer row in the shape QBO returns inside `QueryResponse.Customer`.
-// `email: null` produces a row with no `PrimaryEmailAddr` at all (covers the
-// "Address absent" branch). Any other value goes verbatim to test malformed
-// shapes (string instead of object, etc.) without TS friction.
+// `email: null` produces a row with no `PrimaryEmailAddr` at all — covers the
+// "Address absent" branch.
 function row(
   id: string,
-  email: string | null | { Address?: unknown },
+  email: string | null,
   overrides: Record<string, unknown> = {},
 ) {
   const base = {
@@ -72,10 +70,7 @@ function row(
     ...overrides,
   }
   if (email === null) return base
-  if (typeof email === 'string') {
-    return { ...base, PrimaryEmailAddr: { Address: email } }
-  }
-  return { ...base, PrimaryEmailAddr: email }
+  return { ...base, PrimaryEmailAddr: { Address: email } }
 }
 
 // `customQuery` is a public field on IntuitAPI (`this.wrapWithRetry(this._customQuery)`).
@@ -277,26 +272,6 @@ describe('IntuitAPI#getCustomerByEmail', () => {
     const result = await api.getCustomerByEmail('alice@example.com', undefined)
 
     expect(result?.Id).toBe('3')
-  })
-
-  it('skips rows where PrimaryEmailAddr.Address is non-string without throwing', async () => {
-    // Same guard from a different angle: `Address` exists but is not a
-    // string (number, null, nested object). The `typeof addr === 'string'`
-    // check must short-circuit before `.trim()`.
-    const { api } = makeApi([
-      {
-        Customer: [
-          row('1', { Address: null }),
-          row('2', { Address: 12345 }),
-          row('3', { Address: undefined }),
-          row('4', 'alice@example.com'),
-        ],
-      },
-    ])
-
-    const result = await api.getCustomerByEmail('alice@example.com', undefined)
-
-    expect(result?.Id).toBe('4')
   })
 
   it('returns the first match when multiple customers share the same email and pass the company predicate', async () => {

--- a/test/unit/utils/intuitAPI.test.ts
+++ b/test/unit/utils/intuitAPI.test.ts
@@ -256,14 +256,31 @@ describe('IntuitAPI#getCustomerByEmail', () => {
   })
 
   it('skips rows with missing PrimaryEmailAddr without throwing', async () => {
-    // Defensive behaviour added after review: a row with no email field
-    // must not crash the predicate. Before the fix, accessing `.Address`
-    // on an unexpected shape would throw mid-find().
+    // A row with no email field must not crash the predicate.
     const { api } = makeApi([
       {
         Customer: [
           row('1', null),
           row('2', null),
+          row('3', 'alice@example.com'),
+        ],
+      },
+    ])
+
+    const result = await api.getCustomerByEmail('alice@example.com', undefined)
+
+    expect(result?.Id).toBe('3')
+  })
+
+  it('skips rows with null PrimaryEmailAddr or null Address without ZodError-ing the page', async () => {
+    // Regression guard: a single malformed row must not taint the whole-
+    // page parse. Schema permits PrimaryEmailAddr and Address to be null;
+    // the typeof addr === 'string' predicate skips them.
+    const { api } = makeApi([
+      {
+        Customer: [
+          row('1', null, { PrimaryEmailAddr: null }),
+          row('2', null, { PrimaryEmailAddr: { Address: null } }),
           row('3', 'alice@example.com'),
         ],
       },


### PR DESCRIPTION
## Summary

Brings every `IntuitAPI` method onto a uniform Zod-parse-at-boundary contract and removes `any` from the IntuitAPI surface. Linear: [OUT-3543](https://linear.app/assemblycom/issue/OUT-3543).

**Before:** ~5 methods parsed; ~13 returned raw responses with no validation. Three `as any` casts, one `Record<string, any>` body, three inline TS interfaces, `_customQuery` typed as `any`.

**After:**
- Every method ends with `Schema.parse(raw)` and declares `Promise<z.infer<typeof Schema>>`.
- `_customQuery: Promise<unknown>` — every caller parses an envelope before reading fields.
- Three hoisted overload types replace `as any` with `as unknown as XxxOverloads`.
- `postFetchWithHeaders` + `postFetcher` body narrowed to `unknown`.
- Row + envelope decomposition applied uniformly across Item / Account / Invoice / Payment / Purchase, with dedicated delete and query envelopes.

```
$ rg ': any|<any>|as any' src/utils/intuitAPI.ts src/type/dto/intuitAPI.dto.ts
(empty)
```

## Out of scope

Documented in `docs/superpowers/specs/2026-05-12-out-3543-intuit-response-types-design.md`. Briefly: `copilotAPI.ts` catch-block narrowing, `withRetry` / `withErrorHandler` generics, axios error guards, framework-boundary `any` (logger / crypto / swr / module decls). Copilot webhook + request-body Zod schemas were already in place pre-branch — the work concentrated on response types where the gap was.

## Design choices

- `.passthrough()` not used; consumers only read modeled fields, default `.strip()` matches intent.
- Fault checks stay imperative (separate from shape parsing).
- `_customQuery` returns `unknown`; callers parse the envelope matching their SQL.
- `CustomerListEnvelopeSchema` wraps `CustomerQueryResponseSchema` directly (no duplicate row schema).

## Follow-ups (not blockers)

- **CI test gap:** integration tests mock `@/utils/intuitAPI` entirely, so production `.parse` never runs in CI. Worth a separate ticket: unit suite parsing captured real QBO sample responses against each schema.
- **`postFetcher` returns `Promise<any>`** — local `invoice` / `item` between fetch and parse is `any`; `.Fault` checks read off `any`. Out of scope but worth tightening next.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run --project unit` — 77/77 pass
- [x] `yarn lint:check` / `yarn prettier:check` — clean
- [x] Full suite at branch HEAD — 87/87 (5 unit + 7 integration via testcontainers)
- [ ] Smoke against QBO sandbox before un-drafting (createItem / createCustomer / createInvoice / createPayment / createPurchase / void / delete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)