### PR TITLE
OUT-3742: tighten QBO Fault handling + bind SQL projections to row schemas

### DIFF
--- a/src/app/api/core/utils/withErrorHandler.ts
+++ b/src/app/api/core/utils/withErrorHandler.ts
@@ -114,7 +114,17 @@ export const withErrorHandler = (handler: RequestHandler): RequestHandler => {
         })
       }
 
-      return NextResponse.json({ error: message, errors }, { status })
+      // QBO fault codes (e.g. 6240) are not valid HTTP status values; clamp
+      // to BAD_REQUEST before NextResponse.json. Matches assertNotQBFault's
+      // own fallback and preserves the pre-fix external contract; original
+      // code is kept in `errors`.
+      const httpStatusOut =
+        status >= 200 && status <= 599 ? status : httpStatus.BAD_REQUEST
+
+      return NextResponse.json(
+        { error: message, errors },
+        { status: httpStatusOut },
+      )
     }
   }
 }

--- a/src/app/api/core/utils/withErrorHandler.ts
+++ b/src/app/api/core/utils/withErrorHandler.ts
@@ -114,10 +114,8 @@ export const withErrorHandler = (handler: RequestHandler): RequestHandler => {
         })
       }
 
-      // QBO fault codes (e.g. 6240) are not valid HTTP status values; clamp
-      // to BAD_REQUEST before NextResponse.json. Matches assertNotQBFault's
-      // own fallback and preserves the pre-fix external contract; original
-      // code is kept in `errors`.
+      // QBO fault codes (e.g. 6240) aren't valid HTTP statuses; clamp before
+      // NextResponse.json. Original code is preserved in `errors`.
       const httpStatusOut =
         status >= 200 && status <= 599 ? status : httpStatus.BAD_REQUEST
 

--- a/src/app/api/quickbooks/invoice/invoice.service.ts
+++ b/src/app/api/quickbooks/invoice/invoice.service.ts
@@ -1216,7 +1216,7 @@ export class InvoiceService extends BaseService {
       console.error(
         'InvoiceService#handleInvoiceDeleted | Invoices delete was requested for non-voided record',
       )
-      return // return early if invoice is not voided
+      throw new Error('Invoices delete was requested for non-voided record')
     }
 
     // get invoice sync log

--- a/src/app/api/quickbooks/invoice/invoice.service.ts
+++ b/src/app/api/quickbooks/invoice/invoice.service.ts
@@ -1211,7 +1211,8 @@ export class InvoiceService extends BaseService {
       )
     }
 
-    // Copilot doesn't allow to delete invoice that are not voided. So, just log an error about possible edge cases without returning an error
+    // Copilot only fires delete on voided invoices; surface any other state
+    // as a FAILED log via the webhook catch.
     if (syncedInvoice.status !== InvoiceStatus.VOID) {
       console.error(
         'InvoiceService#handleInvoiceDeleted | Invoices delete was requested for non-voided record',

--- a/src/app/api/quickbooks/invoice/invoice.utils.ts
+++ b/src/app/api/quickbooks/invoice/invoice.utils.ts
@@ -44,16 +44,11 @@ export const findNextAvailableDocNumber = (
  * surfaces in.
  *
  * Live path: APIError thrown from intuitAPI._createInvoice carries the QBO
- * fault payload in its `errors` array (`{ code: '6240', Detail, Message }`).
- * APIError.status lands as 400 because intuitAPI dereferences
- * `Fault.Error?.code` as if it were an object (the QBO Fault.Error is an
- * array); APIError.message is the boilerplate `#IntuitAPIErrorMessage#…`.
- * So the only reliable signal is iterating `errors[]` and matching `code`
- * or the Detail/Message text.
- *
- * Defense-in-depth: also check top-level .status/.code/.message in case any
- * future call site rethrows the inner fault directly or normalizes the
- * APIError differently.
+ * fault payload in its `errors` array (`{ code: 6240, Detail, Message }`).
+ * APIError.status also reflects the QBO code (e.g. 6240),
+ * so the top-level `.status === 6240` branch now fires on real faults.
+ * The `errors[]` walk remains the durable signal — it stays correct if a
+ * caller ever wraps/normalises the APIError without preserving .status.
  */
 export const isQBODuplicateDocNumberError = (err: unknown): boolean => {
   if (!err || typeof err !== 'object' || Array.isArray(err)) return false

--- a/src/app/api/quickbooks/invoice/invoice.utils.ts
+++ b/src/app/api/quickbooks/invoice/invoice.utils.ts
@@ -40,15 +40,9 @@ export const findNextAvailableDocNumber = (
 }
 
 /**
- * Recognizes QBO Error 6240 "Duplicate Document Number" across the shapes it
- * surfaces in.
- *
- * Live path: APIError thrown from intuitAPI._createInvoice carries the QBO
- * fault payload in its `errors` array (`{ code: 6240, Detail, Message }`).
- * APIError.status also reflects the QBO code (e.g. 6240),
- * so the top-level `.status === 6240` branch now fires on real faults.
- * The `errors[]` walk remains the durable signal — it stays correct if a
- * caller ever wraps/normalises the APIError without preserving .status.
+ * Recognizes QBO Error 6240 "Duplicate Document Number". Reads `.status`,
+ * `.code`, `errors[].code`, and message text so it works whether the caller
+ * surfaces the parsed APIError directly or wraps/normalises it.
  */
 export const isQBODuplicateDocNumberError = (err: unknown): boolean => {
   if (!err || typeof err !== 'object' || Array.isArray(err)) return false

--- a/src/type/dto/intuitAPI.dto.ts
+++ b/src/type/dto/intuitAPI.dto.ts
@@ -8,15 +8,15 @@ export const QBNameValueSchema = z.object({
 })
 export type QBNameValueSchemaType = z.infer<typeof QBNameValueSchema>
 
-// QBO documents and returns Fault.Error as an array of typed error objects.
-// `code` is delivered as a string (e.g. "6240"); coerce to number so
-// APIError.status and downstream code-based comparators see a number.
-// `.catch(NaN)` keeps the parse intact for non-numeric codes — Zod's number
-// validator rejects NaN, so without it `z.coerce.number()` would fail the
-// whole schema and assertNotQBFault would silently swallow the fault.
-// assertNotQBFault treats NaN as "no usable code" and falls back to BAD_REQUEST.
+// QBO sends `code` as a string. Coerce to number, or to undefined for
+// missing / null / empty / non-numeric values — never NaN, never a parse
+// failure, so assertNotQBFault can't silently swallow a Fault.
 export const QBFaultErrorSchema = z.object({
-  code: z.coerce.number().catch(NaN).optional(),
+  code: z.unknown().transform((v) => {
+    if (v === undefined || v === null || v === '') return undefined
+    const n = typeof v === 'number' ? v : Number(v)
+    return Number.isFinite(n) ? n : undefined
+  }),
   Message: z.string().optional(),
   Detail: z.string().optional(),
   element: z.string().optional(),
@@ -25,8 +25,7 @@ export type QBFaultErrorSchemaType = z.infer<typeof QBFaultErrorSchema>
 
 export const QBFaultSchema = z.object({
   Fault: z.object({
-    // .default([]) guards against QBO responses where `Fault` is present but
-    // `Error` is absent — without it safeParse would silently no-op the throw.
+    // .default([]) prevents a silent no-op when Fault is present but Error is absent.
     Error: z.array(QBFaultErrorSchema).optional().default([]),
   }),
 })

--- a/src/type/dto/intuitAPI.dto.ts
+++ b/src/type/dto/intuitAPI.dto.ts
@@ -11,11 +11,12 @@ export type QBNameValueSchemaType = z.infer<typeof QBNameValueSchema>
 // QBO documents and returns Fault.Error as an array of typed error objects.
 // `code` is delivered as a string (e.g. "6240"); coerce to number so
 // APIError.status and downstream code-based comparators see a number.
-// Non-numeric codes coerce to NaN — assertNotQBFault treats that as
-// "no usable code" rather than failing the parse, so the Detail/Message
-// payload is still surfaced for diagnostics.
+// `.catch(NaN)` keeps the parse intact for non-numeric codes — Zod's number
+// validator rejects NaN, so without it `z.coerce.number()` would fail the
+// whole schema and assertNotQBFault would silently swallow the fault.
+// assertNotQBFault treats NaN as "no usable code" and falls back to BAD_REQUEST.
 export const QBFaultErrorSchema = z.object({
-  code: z.coerce.number().optional(),
+  code: z.coerce.number().catch(NaN).optional(),
   Message: z.string().optional(),
   Detail: z.string().optional(),
   element: z.string().optional(),

--- a/src/type/dto/intuitAPI.dto.ts
+++ b/src/type/dto/intuitAPI.dto.ts
@@ -8,12 +8,25 @@ export const QBNameValueSchema = z.object({
 })
 export type QBNameValueSchemaType = z.infer<typeof QBNameValueSchema>
 
-// QBO returns Fault on any failed response. Error is loose (object or array)
-// across endpoints; we forward whatever shape arrived so callers/log
-// consumers can inspect it.
+// QBO documents and returns Fault.Error as an array of typed error objects.
+// `code` is delivered as a string (e.g. "6240"); coerce to number so
+// APIError.status and downstream code-based comparators see a number.
+// Non-numeric codes coerce to NaN — assertNotQBFault treats that as
+// "no usable code" rather than failing the parse, so the Detail/Message
+// payload is still surfaced for diagnostics.
+export const QBFaultErrorSchema = z.object({
+  code: z.coerce.number().optional(),
+  Message: z.string().optional(),
+  Detail: z.string().optional(),
+  element: z.string().optional(),
+})
+export type QBFaultErrorSchemaType = z.infer<typeof QBFaultErrorSchema>
+
 export const QBFaultSchema = z.object({
   Fault: z.object({
-    Error: z.unknown().optional(),
+    // .default([]) guards against QBO responses where `Fault` is present but
+    // `Error` is absent — without it safeParse would silently no-op the throw.
+    Error: z.array(QBFaultErrorSchema).optional().default([]),
   }),
 })
 export type QBFaultType = z.infer<typeof QBFaultSchema>

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -5,6 +5,7 @@ import {
 } from '@/app/api/core/exceptions/custom'
 import { OAuthErrorCodes } from '@/constant/intuitErrorCode'
 import { CopilotApiError, MessagableError } from '@/type/CopilotApiError'
+import { QBFaultErrorSchemaType } from '@/type/dto/intuitAPI.dto'
 import { refreshTokenExpireMessage } from '@/utils/auth'
 import { IntuitAPIErrorMessage } from '@/utils/intuitAPI'
 import httpStatus from 'http-status'
@@ -50,7 +51,8 @@ export const getMessageAndCodeFromError = (
     let errorMessage = error.message || message
     const isIntuitError = error.message.includes(IntuitAPIErrorMessage)
     if (isIntuitError) {
-      errorMessage = (error.errors?.[0] as IntuitErrorType).Detail
+      const firstFault = error.errors?.[0] as QBFaultErrorSchemaType | undefined
+      errorMessage = firstFault?.Detail ?? errorMessage
     }
     return {
       message: errorMessage,

--- a/src/utils/intuitAPI.ts
+++ b/src/utils/intuitAPI.ts
@@ -68,10 +68,8 @@ export type IntuitAPITokensType = Pick<
 
 export const IntuitAPIErrorMessage = '#IntuitAPIErrorMessage#'
 
-// Throws an APIError if `raw` is a QBO Fault response; no-op otherwise.
-// APIError.status carries the QBO fault code from errors[0].code (e.g. 6240)
-// when finite, else BAD_REQUEST. withErrorHandler clamps non-HTTP codes
-// before they reach NextResponse.json.
+// APIError.status carries the QBO fault code (e.g. 6240) when available,
+// else BAD_REQUEST. withErrorHandler clamps non-HTTP codes downstream.
 export function assertNotQBFault(raw: unknown, opName: string): void {
   const result = QBFaultSchema.safeParse(raw)
   if (!result.success) return
@@ -79,9 +77,7 @@ export function assertNotQBFault(raw: unknown, opName: string): void {
   CustomLogger.error({ obj: errors, message: 'Error: ' })
   const firstCode = errors[0]?.code
   const code =
-    typeof firstCode === 'number' && Number.isFinite(firstCode)
-      ? firstCode
-      : httpStatus.BAD_REQUEST
+    typeof firstCode === 'number' ? firstCode : httpStatus.BAD_REQUEST
   throw new APIError(code, `${IntuitAPIErrorMessage}${opName}`, errors)
 }
 
@@ -739,8 +735,6 @@ export default class IntuitAPI {
    * findNextAvailableDocNumber to detect collisions and pick the next free
    * suffix before createInvoice. Caps at maxresults=100; if a single prefix
    * has more matches, the caller falls back to catch-6240 retry semantics.
-   * SyncToken is included so a caller can void/delete a duplicate without a
-   * second lookup.
    */
   async _findInvoicesByDocNumberPrefix(
     prefix: string,

--- a/src/utils/intuitAPI.ts
+++ b/src/utils/intuitAPI.ts
@@ -27,7 +27,6 @@ import {
   CompanyInfoType,
   CompanyInfoSchema,
   CustomerQueryResponseType,
-  CustomerQueryResponseSchema,
   QBCustomerResponseSchema,
   QBItemsResponseSchema,
   QBItemsResponseType,
@@ -46,6 +45,7 @@ import {
   SingleIdAndTokenResponseSchema,
   SingleIdAndTokenResponseType,
   QBInvoiceQueryResponseSchema,
+  QBInvoiceRowType,
   CustomerListEnvelopeSchema,
   QBFaultSchema,
 } from '@/type/dto/intuitAPI.dto'
@@ -84,6 +84,47 @@ export function assertNotQBFault(raw: unknown, opName: string): void {
       : httpStatus.BAD_REQUEST
   throw new APIError(code, `${IntuitAPIErrorMessage}${opName}`, errors)
 }
+
+// SELECT projection for each read entity. `satisfies` binds the constant to
+// the row schema's keys — a typo or stale field name fails tsc. Keep in
+// sync with the row schemas in src/type/dto/intuitAPI.dto.ts.
+export const QB_INVOICE_COLUMNS = [
+  'Id',
+  'SyncToken',
+  'DocNumber',
+  'Balance',
+  'TotalAmt',
+  'TxnDate',
+  'DueDate',
+  'PrivateNote',
+  'CustomerRef',
+] as const satisfies ReadonlyArray<keyof QBInvoiceRowType>
+
+export const QB_ITEM_COLUMNS = [
+  'Id',
+  'SyncToken',
+  'Name',
+  'ClassRef',
+  'Active',
+  'UnitPrice',
+  'Description',
+] as const satisfies ReadonlyArray<keyof QBItemRowType>
+
+export const QB_CUSTOMER_COLUMNS = [
+  'Id',
+  'SyncToken',
+  'Active',
+  'CompanyName',
+  'FullyQualifiedName',
+  'PrimaryEmailAddr',
+] as const satisfies ReadonlyArray<keyof CustomerQueryResponseType>
+
+export const QB_ACCOUNT_COLUMNS = [
+  'Id',
+  'Name',
+  'SyncToken',
+  'Active',
+] as const satisfies ReadonlyArray<keyof QBAccountRowType>
 
 type GetACustomerOverloads = {
   (
@@ -283,7 +324,7 @@ export default class IntuitAPI {
     CustomLogger.info({
       message: `IntuitAPI#getSingleIncomeAccount | Income account query start for realmId: ${this.tokens.intuitRealmId}`,
     })
-    const sqlQuery = `SELECT Id, Name, SyncToken, Active FROM Account WHERE AccountType = 'Income' AND AccountSubType = 'SalesOfProductIncome' AND Active = true maxresults 1`
+    const sqlQuery = `select ${QB_ACCOUNT_COLUMNS.join(', ')} from Account where AccountType = 'Income' AND AccountSubType = 'SalesOfProductIncome' AND Active = true maxresults 1`
     const qbIncomeAccountRefInfo = await this.customQuery(sqlQuery)
 
     if (!qbIncomeAccountRefInfo)
@@ -337,7 +378,7 @@ export default class IntuitAPI {
     CustomLogger.info({
       message: `IntuitAPI#getACustomer | Customer query start for realmId: ${this.tokens.intuitRealmId}. Name: ${displayName}, Id: ${id}`,
     })
-    const customerQuery = `SELECT Id, SyncToken, Active, CompanyName, PrimaryEmailAddr FROM Customer WHERE ${queryCondition}`
+    const customerQuery = `select ${QB_CUSTOMER_COLUMNS.join(', ')} from Customer where ${queryCondition}`
     const qbCustomers = await this.customQuery(customerQuery)
 
     if (!qbCustomers) return null
@@ -368,7 +409,7 @@ export default class IntuitAPI {
     let startPosition = 1
 
     while (true) {
-      const customerQuery = `SELECT Id, SyncToken, Active, CompanyName, PrimaryEmailAddr FROM Customer WHERE Active IN (true, false) ORDERBY Id ASC STARTPOSITION ${startPosition} MAXRESULTS ${pageSize}`
+      const customerQuery = `select ${QB_CUSTOMER_COLUMNS.join(', ')} from Customer where Active IN (true, false) ORDERBY Id ASC STARTPOSITION ${startPosition} MAXRESULTS ${pageSize}`
       const qbCustomers = await this.customQuery(customerQuery)
       const envelope = CustomerListEnvelopeSchema.parse(qbCustomers ?? {})
       const customers = envelope.Customer ?? []
@@ -508,7 +549,7 @@ export default class IntuitAPI {
     CustomLogger.info({
       message: `IntuitAPI#getAnItem | Item query start for realmId: ${this.tokens.intuitRealmId}. Condition: ${queryCondition}`,
     })
-    const customerQuery = `select Id, SyncToken, ClassRef, Active, Name, UnitPrice from Item where ${queryCondition} maxresults 1`
+    const customerQuery = `select ${QB_ITEM_COLUMNS.join(', ')} from Item where ${queryCondition} maxresults 1`
     const qbItem = await this.customQuery(customerQuery)
 
     if (!qbItem) return null
@@ -521,9 +562,8 @@ export default class IntuitAPI {
     CustomLogger.info({
       message: `IntuitAPI#getAllItems | Item query start for realmId: ${this.tokens.intuitRealmId}`,
     })
-    // Columns are fixed to match QBItemsResponseSchema; callers don't need
-    // to know the projection. Service items only.
-    const customerQuery = `select Id, Name, UnitPrice, Description, SyncToken from Item where Type = 'Service' maxresults ${limit}`
+    // Service items only.
+    const customerQuery = `select ${QB_ITEM_COLUMNS.join(', ')} from Item where Type = 'Service' maxresults ${limit}`
     CustomLogger.info({
       obj: { customerQuery },
       message: 'IntuitAPI#getAllItems',
@@ -675,7 +715,7 @@ export default class IntuitAPI {
       obj: { invoiceNumber },
       message: `IntuitAPI#getInvoice | invoice query start for realmId: ${this.tokens.intuitRealmId}. `,
     })
-    const query = `select Id, SyncToken, DocNumber from Invoice where DocNumber = '${escapeForQBQuery(invoiceNumber)}' maxresults 1`
+    const query = `select ${QB_INVOICE_COLUMNS.join(', ')} from Invoice where DocNumber = '${escapeForQBQuery(invoiceNumber)}' maxresults 1`
     const invoice = await this.customQuery(query)
 
     if (!invoice)
@@ -699,16 +739,18 @@ export default class IntuitAPI {
    * findNextAvailableDocNumber to detect collisions and pick the next free
    * suffix before createInvoice. Caps at maxresults=100; if a single prefix
    * has more matches, the caller falls back to catch-6240 retry semantics.
+   * SyncToken is included so a caller can void/delete a duplicate without a
+   * second lookup.
    */
   async _findInvoicesByDocNumberPrefix(
     prefix: string,
-  ): Promise<Array<{ Id: string; DocNumber: string }>> {
+  ): Promise<Array<{ Id: string; DocNumber: string; SyncToken: string }>> {
     // LIKE-wildcard chars in user input would broaden the match. Assembly
     // invoice numbers don't contain '%' or '_', but escape defensively.
     const escapedPrefix = escapeForQBQuery(prefix)
       .replace(/%/g, '\\%')
       .replace(/_/g, '\\_')
-    const query = `select Id, SyncToken, DocNumber from Invoice where DocNumber LIKE '${escapedPrefix}%' maxresults 100`
+    const query = `select ${QB_INVOICE_COLUMNS.join(', ')} from Invoice where DocNumber LIKE '${escapedPrefix}%' maxresults 100`
     const response = await this.customQuery(query)
     if (!response) {
       throw new APIError(
@@ -721,6 +763,7 @@ export default class IntuitAPI {
     return envelope.Invoice.map((inv) => ({
       Id: inv.Id,
       DocNumber: inv.DocNumber ?? '',
+      SyncToken: inv.SyncToken,
     }))
   }
 
@@ -838,7 +881,7 @@ export default class IntuitAPI {
       : `Id = '${id}'`
     queryCondition = `${queryCondition} AND Active IN (true${includeInactive ? ', false' : ''})` // By default, QB returns only active items.
 
-    const query = `SELECT Id, SyncToken, Active, Name FROM Account where ${queryCondition}`
+    const query = `select ${QB_ACCOUNT_COLUMNS.join(', ')} from Account where ${queryCondition}`
     const customQueryRes = await this.customQuery(query)
 
     if (!customQueryRes) return null

--- a/src/utils/intuitAPI.ts
+++ b/src/utils/intuitAPI.ts
@@ -69,30 +69,20 @@ export type IntuitAPITokensType = Pick<
 export const IntuitAPIErrorMessage = '#IntuitAPIErrorMessage#'
 
 // Throws an APIError if `raw` is a QBO Fault response; no-op otherwise.
-// Replaces the duplicated `if (raw?.Fault) throw ...` block in every method.
-// Fault.Error.code is preserved only when numeric (HTTP-safe); QBO's
-// string codes fall back to BAD_REQUEST as before.
+// APIError.status carries the QBO fault code from errors[0].code (e.g. 6240)
+// when finite, else BAD_REQUEST. withErrorHandler clamps non-HTTP codes
+// before they reach NextResponse.json.
 export function assertNotQBFault(raw: unknown, opName: string): void {
   const result = QBFaultSchema.safeParse(raw)
   if (!result.success) return
-  const error = result.data.Fault.Error
-  CustomLogger.error({ obj: error, message: 'Error: ' })
+  const errors = result.data.Fault.Error
+  CustomLogger.error({ obj: errors, message: 'Error: ' })
+  const firstCode = errors[0]?.code
   const code =
-    error &&
-    typeof error === 'object' &&
-    !Array.isArray(error) &&
-    'code' in error &&
-    typeof (error as { code: unknown }).code === 'number'
-      ? (error as { code: number }).code
+    typeof firstCode === 'number' && Number.isFinite(firstCode)
+      ? firstCode
       : httpStatus.BAD_REQUEST
-  // APIError.errors is typed unknown[] — pass array Errors verbatim, drop
-  // non-array shapes to undefined rather than casting (the message + the
-  // logged error above retain the diagnostic detail).
-  throw new APIError(
-    code,
-    `${IntuitAPIErrorMessage}${opName}`,
-    Array.isArray(error) ? error : undefined,
-  )
+  throw new APIError(code, `${IntuitAPIErrorMessage}${opName}`, errors)
 }
 
 type GetACustomerOverloads = {

--- a/test/unit/utils/intuitAPI.queryColumns.test.ts
+++ b/test/unit/utils/intuitAPI.queryColumns.test.ts
@@ -1,7 +1,6 @@
-// Regression guard for QB_*_COLUMNS in src/utils/intuitAPI.ts. Asserting
-// "constant ⊇ schema-required keys" catches drops that would ZodError at
-// runtime. Optional-field drops are silent (callers just get undefined) —
-// if you remove an optional column, verify every caller that reads it.
+// Asserts each QB_*_COLUMNS constant stays a superset of its schema's
+// required keys. Optional-field drops still pass — verify callers if you
+// remove one.
 
 import { describe, it, expect } from 'vitest'
 import {
@@ -24,13 +23,13 @@ const requiredKeysOf = (shape: Record<string, ZodTypeAny>): string[] =>
     .map(([k]) => k)
 
 describe('QB_INVOICE_COLUMNS', () => {
-  it('includes every required field of QBInvoiceRowSchema', () => {
+  it('selects every column the invoice schema marks as required', () => {
     for (const key of requiredKeysOf(QBInvoiceRowSchema.shape)) {
       expect(QB_INVOICE_COLUMNS).toContain(key)
     }
   })
 
-  it('only references fields that exist on QBInvoiceRowSchema', () => {
+  it('does not list any column that the invoice schema does not define', () => {
     const schemaKeys = new Set(Object.keys(QBInvoiceRowSchema.shape))
     for (const col of QB_INVOICE_COLUMNS) {
       expect(schemaKeys.has(col)).toBe(true)
@@ -39,13 +38,13 @@ describe('QB_INVOICE_COLUMNS', () => {
 })
 
 describe('QB_ITEM_COLUMNS', () => {
-  it('includes every required field of QBItemRowSchema', () => {
+  it('selects every column the item schema marks as required', () => {
     for (const key of requiredKeysOf(QBItemRowSchema.shape)) {
       expect(QB_ITEM_COLUMNS).toContain(key)
     }
   })
 
-  it('only references fields that exist on QBItemRowSchema', () => {
+  it('does not list any column that the item schema does not define', () => {
     const schemaKeys = new Set(Object.keys(QBItemRowSchema.shape))
     for (const col of QB_ITEM_COLUMNS) {
       expect(schemaKeys.has(col)).toBe(true)
@@ -54,13 +53,13 @@ describe('QB_ITEM_COLUMNS', () => {
 })
 
 describe('QB_CUSTOMER_COLUMNS', () => {
-  it('includes every required field of CustomerQueryResponseSchema', () => {
+  it('selects every column the customer schema marks as required', () => {
     for (const key of requiredKeysOf(CustomerQueryResponseSchema.shape)) {
       expect(QB_CUSTOMER_COLUMNS).toContain(key)
     }
   })
 
-  it('only references fields that exist on CustomerQueryResponseSchema', () => {
+  it('does not list any column that the customer schema does not define', () => {
     const schemaKeys = new Set(Object.keys(CustomerQueryResponseSchema.shape))
     for (const col of QB_CUSTOMER_COLUMNS) {
       expect(schemaKeys.has(col)).toBe(true)
@@ -69,13 +68,13 @@ describe('QB_CUSTOMER_COLUMNS', () => {
 })
 
 describe('QB_ACCOUNT_COLUMNS', () => {
-  it('includes every required field of QBAccountRowSchema', () => {
+  it('selects every column the account schema marks as required', () => {
     for (const key of requiredKeysOf(QBAccountRowSchema.shape)) {
       expect(QB_ACCOUNT_COLUMNS).toContain(key)
     }
   })
 
-  it('only references fields that exist on QBAccountRowSchema', () => {
+  it('does not list any column that the account schema does not define', () => {
     const schemaKeys = new Set(Object.keys(QBAccountRowSchema.shape))
     for (const col of QB_ACCOUNT_COLUMNS) {
       expect(schemaKeys.has(col)).toBe(true)

--- a/test/unit/utils/intuitAPI.queryColumns.test.ts
+++ b/test/unit/utils/intuitAPI.queryColumns.test.ts
@@ -1,0 +1,84 @@
+// Regression guard for QB_*_COLUMNS in src/utils/intuitAPI.ts. Asserting
+// "constant ⊇ schema-required keys" catches drops that would ZodError at
+// runtime. Optional-field drops are silent (callers just get undefined) —
+// if you remove an optional column, verify every caller that reads it.
+
+import { describe, it, expect } from 'vitest'
+import {
+  QB_ACCOUNT_COLUMNS,
+  QB_CUSTOMER_COLUMNS,
+  QB_INVOICE_COLUMNS,
+  QB_ITEM_COLUMNS,
+} from '@/utils/intuitAPI'
+import {
+  CustomerQueryResponseSchema,
+  QBAccountRowSchema,
+  QBInvoiceRowSchema,
+  QBItemRowSchema,
+} from '@/type/dto/intuitAPI.dto'
+import type { ZodTypeAny } from 'zod'
+
+const requiredKeysOf = (shape: Record<string, ZodTypeAny>): string[] =>
+  Object.entries(shape)
+    .filter(([, s]) => !s.isOptional())
+    .map(([k]) => k)
+
+describe('QB_INVOICE_COLUMNS', () => {
+  it('includes every required field of QBInvoiceRowSchema', () => {
+    for (const key of requiredKeysOf(QBInvoiceRowSchema.shape)) {
+      expect(QB_INVOICE_COLUMNS).toContain(key)
+    }
+  })
+
+  it('only references fields that exist on QBInvoiceRowSchema', () => {
+    const schemaKeys = new Set(Object.keys(QBInvoiceRowSchema.shape))
+    for (const col of QB_INVOICE_COLUMNS) {
+      expect(schemaKeys.has(col)).toBe(true)
+    }
+  })
+})
+
+describe('QB_ITEM_COLUMNS', () => {
+  it('includes every required field of QBItemRowSchema', () => {
+    for (const key of requiredKeysOf(QBItemRowSchema.shape)) {
+      expect(QB_ITEM_COLUMNS).toContain(key)
+    }
+  })
+
+  it('only references fields that exist on QBItemRowSchema', () => {
+    const schemaKeys = new Set(Object.keys(QBItemRowSchema.shape))
+    for (const col of QB_ITEM_COLUMNS) {
+      expect(schemaKeys.has(col)).toBe(true)
+    }
+  })
+})
+
+describe('QB_CUSTOMER_COLUMNS', () => {
+  it('includes every required field of CustomerQueryResponseSchema', () => {
+    for (const key of requiredKeysOf(CustomerQueryResponseSchema.shape)) {
+      expect(QB_CUSTOMER_COLUMNS).toContain(key)
+    }
+  })
+
+  it('only references fields that exist on CustomerQueryResponseSchema', () => {
+    const schemaKeys = new Set(Object.keys(CustomerQueryResponseSchema.shape))
+    for (const col of QB_CUSTOMER_COLUMNS) {
+      expect(schemaKeys.has(col)).toBe(true)
+    }
+  })
+})
+
+describe('QB_ACCOUNT_COLUMNS', () => {
+  it('includes every required field of QBAccountRowSchema', () => {
+    for (const key of requiredKeysOf(QBAccountRowSchema.shape)) {
+      expect(QB_ACCOUNT_COLUMNS).toContain(key)
+    }
+  })
+
+  it('only references fields that exist on QBAccountRowSchema', () => {
+    const schemaKeys = new Set(Object.keys(QBAccountRowSchema.shape))
+    for (const col of QB_ACCOUNT_COLUMNS) {
+      expect(schemaKeys.has(col)).toBe(true)
+    }
+  })
+})

--- a/test/unit/utils/intuitAPI.responses.test.ts
+++ b/test/unit/utils/intuitAPI.responses.test.ts
@@ -102,10 +102,12 @@ describe('IntuitAPI customQuery-based reads', () => {
   })
 
   it('getSingleIncomeAccount falls back to BAD_REQUEST when Fault.Error[0].code is missing or non-numeric', async () => {
-    // Edge case: QBO returns a fault with no code or a non-numeric code.
-    // We don't want to fail Zod parsing (the Detail/Message are still useful
-    // diagnostics), so the schema coerces and assertNotQBFault treats NaN
-    // (and undefined) as "no usable code" and falls back to BAD_REQUEST.
+    // Missing code: .optional() short-circuits before number coercion → undefined.
+    // Non-numeric code: schema's .catch(NaN) keeps the parse intact → NaN.
+    // Either way assertNotQBFault's Number.isFinite check fails and falls
+    // back to BAD_REQUEST, preserving Detail/Message for diagnostics. This
+    // test exercises the missing branch; the non-numeric branch relies on
+    // the same fallback path via the .catch(NaN) schema guard.
     vi.mocked(getFetcher).mockResolvedValue({
       Fault: {
         Error: [{ Message: 'Unknown', Detail: 'no code field' }],

--- a/test/unit/utils/intuitAPI.responses.test.ts
+++ b/test/unit/utils/intuitAPI.responses.test.ts
@@ -58,7 +58,7 @@ describe('IntuitAPI customQuery-based reads', () => {
     vi.clearAllMocks()
   })
 
-  it('getSingleIncomeAccount parses the SQL it actually issues (Id + Name + SyncToken + Active)', async () => {
+  it('getSingleIncomeAccount returns the income account when QBO responds with a single matching row', async () => {
     // Regression guard: SQL projection must satisfy QBAccountRowSchema.
     vi.mocked(getFetcher).mockResolvedValue(
       queryResponse({
@@ -68,6 +68,7 @@ describe('IntuitAPI customQuery-based reads', () => {
             Name: 'Sales of Product Income',
             SyncToken: '0',
             Active: true,
+            AccountType: 'Income',
           },
         ],
       }),
@@ -84,11 +85,7 @@ describe('IntuitAPI customQuery-based reads', () => {
     })
   })
 
-  it('getSingleIncomeAccount throws APIError on Fault response with QBO code on status and typed errors[]', async () => {
-    // Regression guard for OUT-3742: previously APIError.status was always
-    // BAD_REQUEST because assertNotQBFault ignored the array branch. Now the
-    // QBO numeric code (coerced from the QBO string) surfaces on .status, and
-    // .errors is the typed array from QBFaultErrorSchema.
+  it('getSingleIncomeAccount throws an APIError whose status matches the QBO fault code', async () => {
     vi.mocked(getFetcher).mockResolvedValue(faultResponse())
 
     const api = makeApi()
@@ -101,13 +98,10 @@ describe('IntuitAPI customQuery-based reads', () => {
     ])
   })
 
-  it('getSingleIncomeAccount falls back to BAD_REQUEST when Fault.Error[0].code is missing or non-numeric', async () => {
-    // Missing code: .optional() short-circuits before number coercion → undefined.
-    // Non-numeric code: schema's .catch(NaN) keeps the parse intact → NaN.
-    // Either way assertNotQBFault's Number.isFinite check fails and falls
-    // back to BAD_REQUEST, preserving Detail/Message for diagnostics. This
-    // test exercises the missing branch; the non-numeric branch relies on
-    // the same fallback path via the .catch(NaN) schema guard.
+  it('getSingleIncomeAccount falls back to status 400 when the QBO fault has no usable code', async () => {
+    // Schema maps missing / null / empty / non-numeric `code` to undefined;
+    // assertNotQBFault falls back to BAD_REQUEST. Test covers the missing
+    // branch; the others converge on the same undefined output.
     vi.mocked(getFetcher).mockResolvedValue({
       Fault: {
         Error: [{ Message: 'Unknown', Detail: 'no code field' }],
@@ -122,7 +116,7 @@ describe('IntuitAPI customQuery-based reads', () => {
     expect((err.errors as Array<{ code?: number }>)[0].code).toBeUndefined()
   })
 
-  it('getAllItems parses rows including null Description (QBO returns null for empty)', async () => {
+  it('getAllItems returns every item, including rows whose Description is null', async () => {
     vi.mocked(getFetcher).mockResolvedValue(
       queryResponse({
         Item: [
@@ -157,7 +151,7 @@ describe('IntuitAPI customQuery-based reads', () => {
     })
   })
 
-  it('getAllItems returns parsed empty array when QBO omits the Item key', async () => {
+  it('getAllItems returns an empty array when QBO omits the Item key entirely', async () => {
     vi.mocked(getFetcher).mockResolvedValue(queryResponse({}))
 
     const api = makeApi()
@@ -166,7 +160,7 @@ describe('IntuitAPI customQuery-based reads', () => {
     expect(result).toEqual([])
   })
 
-  it('getAnAccount parses a single-row account match', async () => {
+  it('getAnAccount returns the account when QBO responds with a single match', async () => {
     vi.mocked(getFetcher).mockResolvedValue(
       queryResponse({
         Account: [{ Id: '7', Name: 'Assets', SyncToken: '0', Active: true }],
@@ -180,7 +174,7 @@ describe('IntuitAPI customQuery-based reads', () => {
     expect(result?.SyncToken).toBe('0')
   })
 
-  it('getAnAccount returns null when no Account key is present', async () => {
+  it('getAnAccount returns null when QBO returns no Account in the response', async () => {
     vi.mocked(getFetcher).mockResolvedValue(queryResponse({}))
 
     const api = makeApi()
@@ -189,7 +183,7 @@ describe('IntuitAPI customQuery-based reads', () => {
     expect(result).toBeNull()
   })
 
-  it('getAnItem parses a single-row item match with the SQL columns it projects', async () => {
+  it('getAnItem returns the item when QBO responds with a single match', async () => {
     vi.mocked(getFetcher).mockResolvedValue(
       queryResponse({
         Item: [
@@ -213,7 +207,7 @@ describe('IntuitAPI customQuery-based reads', () => {
     expect(result?.UnitPrice).toBe(50)
   })
 
-  it('getInvoice parses an invoice match and reduces to Id+SyncToken', async () => {
+  it('getInvoice returns the invoice Id and SyncToken when a match is found', async () => {
     vi.mocked(getFetcher).mockResolvedValue(
       queryResponse({
         Invoice: [{ Id: '100', SyncToken: '0', DocNumber: 'INV-1' }],
@@ -226,7 +220,7 @@ describe('IntuitAPI customQuery-based reads', () => {
     expect(result).toEqual({ Id: '100', SyncToken: '0' })
   })
 
-  it('getInvoice returns null when QBO returns an empty Invoice array', async () => {
+  it('getInvoice returns null when QBO returns an empty Invoice list', async () => {
     vi.mocked(getFetcher).mockResolvedValue(queryResponse({ Invoice: [] }))
 
     const api = makeApi()
@@ -235,7 +229,7 @@ describe('IntuitAPI customQuery-based reads', () => {
     expect(result).toBeNull()
   })
 
-  it('getCompanyInfo tolerates a CompanyInfo row without Country', async () => {
+  it('getCompanyInfo returns the row even when Country is missing', async () => {
     vi.mocked(getFetcher).mockResolvedValue(
       queryResponse({ CompanyInfo: [{}] }),
     )
@@ -246,7 +240,7 @@ describe('IntuitAPI customQuery-based reads', () => {
     expect(result.Country).toBeUndefined()
   })
 
-  it('getCompanyInfo passes Country through when present', async () => {
+  it('getCompanyInfo returns the Country when QBO includes it', async () => {
     vi.mocked(getFetcher).mockResolvedValue(
       queryResponse({ CompanyInfo: [{ Country: 'US' }] }),
     )
@@ -257,7 +251,7 @@ describe('IntuitAPI customQuery-based reads', () => {
     expect(result.Country).toBe('US')
   })
 
-  it('getACustomer parses a single-row customer match', async () => {
+  it('getACustomer returns the customer when QBO responds with a single match', async () => {
     vi.mocked(getFetcher).mockResolvedValue(
       queryResponse({
         Customer: [
@@ -285,7 +279,7 @@ describe('IntuitAPI POST-based writes', () => {
     vi.clearAllMocks()
   })
 
-  it('createInvoice parses the envelope and returns the full response', async () => {
+  it('createInvoice returns the created invoice when QBO accepts the request', async () => {
     vi.mocked(postFetcher).mockResolvedValue({
       Invoice: {
         Id: '500',
@@ -306,10 +300,7 @@ describe('IntuitAPI POST-based writes', () => {
     expect(result.Invoice.SyncToken).toBe('0')
   })
 
-  it('createInvoice throws APIError on Fault with QBO code on status', async () => {
-    // Mirrors the read-path Fault assertion: status carries the coerced QBO
-    // code, errors[] is the typed array — guards against a future regression
-    // that limits the fix to the GET path.
+  it('createInvoice throws an APIError whose status matches the QBO fault code', async () => {
     vi.mocked(postFetcher).mockResolvedValue(faultResponse())
 
     const api = makeApi()
@@ -328,7 +319,7 @@ describe('IntuitAPI POST-based writes', () => {
     ])
   })
 
-  it('createCustomer parses the envelope and returns the inner Customer', async () => {
+  it('createCustomer returns the created customer when QBO accepts the request', async () => {
     vi.mocked(postFetcher).mockResolvedValue({
       Customer: {
         Id: '50',
@@ -347,7 +338,7 @@ describe('IntuitAPI POST-based writes', () => {
     expect(result.FullyQualifiedName).toBe('Acme')
   })
 
-  it('createItem parses the envelope and returns the inner Item', async () => {
+  it('createItem returns the created item when QBO accepts the request', async () => {
     vi.mocked(postFetcher).mockResolvedValue({
       Item: {
         Id: '200',
@@ -370,7 +361,7 @@ describe('IntuitAPI POST-based writes', () => {
     expect(result.UnitPrice).toBe(25)
   })
 
-  it('createAccount parses the envelope and returns the inner Account', async () => {
+  it('createAccount returns the created account when QBO accepts the request', async () => {
     vi.mocked(postFetcher).mockResolvedValue({
       Account: { Id: '300', Name: 'New Asset', SyncToken: '0', Active: true },
     })
@@ -387,7 +378,7 @@ describe('IntuitAPI POST-based writes', () => {
     expect(result.Name).toBe('New Asset')
   })
 
-  it('createPayment parses the envelope and returns the full response', async () => {
+  it('createPayment returns the created payment when QBO accepts the request', async () => {
     vi.mocked(postFetcher).mockResolvedValue({
       Payment: { Id: '400', SyncToken: '0', TotalAmt: 100 },
     })
@@ -403,7 +394,7 @@ describe('IntuitAPI POST-based writes', () => {
     expect(result.Payment.SyncToken).toBe('0')
   })
 
-  it('voidInvoice parses the envelope returned by void operation', async () => {
+  it('voidInvoice returns the voided invoice when QBO confirms the void', async () => {
     vi.mocked(postFetcher).mockResolvedValue({
       Invoice: { Id: '500', SyncToken: '1', DocNumber: 'INV-500' },
     })
@@ -415,7 +406,7 @@ describe('IntuitAPI POST-based writes', () => {
     expect(result.Invoice.SyncToken).toBe('1')
   })
 
-  it('deleteInvoice parses the deletion-confirmation envelope (no full row)', async () => {
+  it('deleteInvoice returns the deletion confirmation when QBO confirms the delete', async () => {
     vi.mocked(postFetcher).mockResolvedValue({
       Invoice: { Id: '500', status: 'Deleted', domain: 'QBO' },
     })

--- a/test/unit/utils/intuitAPI.responses.test.ts
+++ b/test/unit/utils/intuitAPI.responses.test.ts
@@ -84,11 +84,40 @@ describe('IntuitAPI customQuery-based reads', () => {
     })
   })
 
-  it('getSingleIncomeAccount throws APIError on Fault response', async () => {
+  it('getSingleIncomeAccount throws APIError on Fault response with QBO code on status and typed errors[]', async () => {
+    // Regression guard for OUT-3742: previously APIError.status was always
+    // BAD_REQUEST because assertNotQBFault ignored the array branch. Now the
+    // QBO numeric code (coerced from the QBO string) surfaces on .status, and
+    // .errors is the typed array from QBFaultErrorSchema.
     vi.mocked(getFetcher).mockResolvedValue(faultResponse())
 
     const api = makeApi()
-    await expect(api.getSingleIncomeAccount()).rejects.toBeInstanceOf(APIError)
+    const err = await api.getSingleIncomeAccount().catch((e) => e)
+
+    expect(err).toBeInstanceOf(APIError)
+    expect(err.status).toBe(6000)
+    expect(err.errors).toEqual([
+      { code: 6000, Message: 'Bad request', Detail: 'detail' },
+    ])
+  })
+
+  it('getSingleIncomeAccount falls back to BAD_REQUEST when Fault.Error[0].code is missing or non-numeric', async () => {
+    // Edge case: QBO returns a fault with no code or a non-numeric code.
+    // We don't want to fail Zod parsing (the Detail/Message are still useful
+    // diagnostics), so the schema coerces and assertNotQBFault treats NaN
+    // (and undefined) as "no usable code" and falls back to BAD_REQUEST.
+    vi.mocked(getFetcher).mockResolvedValue({
+      Fault: {
+        Error: [{ Message: 'Unknown', Detail: 'no code field' }],
+      },
+    })
+
+    const api = makeApi()
+    const err = await api.getSingleIncomeAccount().catch((e) => e)
+
+    expect(err).toBeInstanceOf(APIError)
+    expect(err.status).toBe(400)
+    expect((err.errors as Array<{ code?: number }>)[0].code).toBeUndefined()
   })
 
   it('getAllItems parses rows including null Description (QBO returns null for empty)', async () => {
@@ -275,17 +304,26 @@ describe('IntuitAPI POST-based writes', () => {
     expect(result.Invoice.SyncToken).toBe('0')
   })
 
-  it('createInvoice throws APIError on Fault', async () => {
+  it('createInvoice throws APIError on Fault with QBO code on status', async () => {
+    // Mirrors the read-path Fault assertion: status carries the coerced QBO
+    // code, errors[] is the typed array — guards against a future regression
+    // that limits the fix to the GET path.
     vi.mocked(postFetcher).mockResolvedValue(faultResponse())
 
     const api = makeApi()
-    await expect(
-      api.createInvoice({
+    const err = await api
+      .createInvoice({
         Line: [],
         CustomerRef: { value: 'c1' },
         PrivateNote: 'Assembly invoice: TEST-001',
-      }),
-    ).rejects.toBeInstanceOf(APIError)
+      })
+      .catch((e) => e)
+
+    expect(err).toBeInstanceOf(APIError)
+    expect(err.status).toBe(6000)
+    expect(err.errors).toEqual([
+      { code: 6000, Message: 'Bad request', Detail: 'detail' },
+    ])
   })
 
   it('createCustomer parses the envelope and returns the inner Customer', async () => {


### PR DESCRIPTION
## Problem

- `assertNotQBFault` only read `code` on the non-array branch, so `APIError.status` was always 400 for real QBO faults.
- 8 hand-written QBO SELECT projections drifted from their row schemas — typos/required-key changes only surfaced at runtime.

## Shipped

- Tightened `QBFaultSchema`; simplified `assertNotQBFault` to read `errors[0]?.code`. Clamp non-HTTP statuses in `withErrorHandler`.
- 4 typed constants (`QB_INVOICE_COLUMNS`, `QB_ITEM_COLUMNS`, `QB_CUSTOMER_COLUMNS`, `QB_ACCOUNT_COLUMNS`) bind each SELECT to its row schema via `satisfies`. Regression test guards required-key supersets.
- Drive-bys: `handleInvoiceDeleted` throws on non-voided delete; `getMessageAndCodeFromError` guards an empty `errors[]`.

## Code sites

- `src/type/dto/intuitAPI.dto.ts`
- `src/utils/intuitAPI.ts`
- `src/app/api/core/utils/withErrorHandler.ts`
- `src/app/api/quickbooks/invoice/invoice.service.ts`
- `src/utils/error.ts`
- `test/unit/utils/intuitAPI.{responses,queryColumns}.test.ts`

## Behavior change

- `qb_sync_logs.failed_record_category` for live 6000/6190 faults now resolves to `ACCOUNT` (was `QB_API_ERROR`) because `getCategory` reads the real status. HTTP response still 400.