### PR TITLE
OUT-3922: integration tests for invoice.deleted webhook event

### DIFF
--- a/test/fixtures/invoiceDeleted.webhook.ts
+++ b/test/fixtures/invoiceDeleted.webhook.ts
@@ -1,0 +1,30 @@
+import type { z } from 'zod'
+
+import { InvoiceDeletedResponseSchema } from '@/type/dto/webhook.dto'
+import {
+  TEST_CLIENT_ID,
+  TEST_COPILOT_INVOICE_ID,
+  TEST_INVOICE_NUMBER,
+} from '@test/helpers/seed'
+
+type Envelope = {
+  eventType: 'invoice.deleted'
+  object: 'invoice'
+}
+
+// Deleted is dispatched as `payload.data` and parsed flat (no status/tax).
+type InvoiceDeletedFixture = Envelope & {
+  data: z.input<typeof InvoiceDeletedResponseSchema>
+}
+
+export const invoiceDeletedPayload: InvoiceDeletedFixture = {
+  eventType: 'invoice.deleted',
+  object: 'invoice',
+  data: {
+    id: TEST_COPILOT_INVOICE_ID,
+    number: TEST_INVOICE_NUMBER,
+    total: 60000,
+    clientId: TEST_CLIENT_ID,
+    companyId: '',
+  },
+}

--- a/test/helpers/invoiceDeletedTestSetup.ts
+++ b/test/helpers/invoiceDeletedTestSetup.ts
@@ -1,0 +1,39 @@
+import { beforeEach, afterEach, vi } from 'vitest'
+import { truncateAllTestTables } from '@test/helpers/testDb'
+import {
+  installMockApis,
+  type MockCopilotAPI,
+  type MockIntuitAPI,
+} from '@test/helpers/mocks'
+
+type InstallOpts = Parameters<typeof installMockApis>[0]
+
+export interface InvoiceDeletedTestHandle {
+  copilot: MockCopilotAPI
+  intuit: MockIntuitAPI
+}
+
+/**
+ * beforeEach (truncate + installMockApis) and afterEach (clearAllMocks) hooks
+ * for invoice.deleted tests. Mirrors `setupInvoiceVoidedTest`; `optsFactory`
+ * runs once per test so override `vi.fn()`s are freshly instantiated.
+ */
+export function setupInvoiceDeletedTest(
+  optsFactory?: () => InstallOpts,
+): InvoiceDeletedTestHandle {
+  const handle = {} as InvoiceDeletedTestHandle
+
+  beforeEach(async () => {
+    await truncateAllTestTables()
+    const { copilot, intuit } = installMockApis(optsFactory?.())
+    handle.copilot = copilot
+    handle.intuit = intuit
+  })
+
+  afterEach(() => {
+    // clearAllMocks (not restoreAllMocks) keeps the module-level mock factories installed.
+    vi.clearAllMocks()
+  })
+
+  return handle
+}

--- a/test/helpers/mocks.ts
+++ b/test/helpers/mocks.ts
@@ -134,6 +134,14 @@ export function createMockIntuitAPI(overrides: IntuitAPIOverrides = {}) {
     voidInvoice: vi.fn().mockResolvedValue({
       Invoice: { Id: TEST_QB_INVOICE_ID, SyncToken: '1' },
     }),
+    // invoice.deleted checks QBO first; null = the QBO-absent path.
+    getInvoice: vi.fn().mockResolvedValue({
+      Id: TEST_QB_INVOICE_ID,
+      SyncToken: '0',
+    }),
+    deleteInvoice: vi.fn().mockResolvedValue({
+      Invoice: { Id: TEST_QB_INVOICE_ID, status: 'Deleted' },
+    }),
     createPurchase: vi.fn().mockResolvedValue({
       Purchase: { Id: TEST_QB_PURCHASE_ID, SyncToken: '0' },
     }),

--- a/test/integration/quickbooks/invoiceDeleted/happyPath.test.ts
+++ b/test/integration/quickbooks/invoiceDeleted/happyPath.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { and, eq } from 'drizzle-orm'
+
+import { db } from '@/db'
+import { QBSyncLog } from '@/db/schema/qbSyncLogs'
+import { QBInvoiceSync } from '@/db/schema/qbInvoiceSync'
+import { EntityType, EventType, LogStatus } from '@/app/api/core/types/log'
+import { InvoiceStatus } from '@/app/api/core/types/invoice'
+
+import { invoiceDeletedPayload } from '@test/fixtures/invoiceDeleted.webhook'
+import {
+  seedHealthyPortal,
+  seedQBCustomer,
+  seedQBInvoiceSync,
+  seedInvoiceCreatedLog,
+  TEST_PORTAL_ID,
+  TEST_INVOICE_NUMBER,
+  TEST_COPILOT_INVOICE_ID,
+  TEST_QB_INVOICE_ID,
+} from '@test/helpers/seed'
+import { setupInvoiceDeletedTest } from '@test/helpers/invoiceDeletedTestSetup'
+import { postWebhook } from '@test/helpers/webhook'
+
+describe('POST /api/quickbooks/webhook — invoice.deleted (invoice deleted in QuickBooks)', () => {
+  const apis = setupInvoiceDeletedTest()
+
+  it('deletes the QuickBooks invoice, marks the sync row deleted, and logs the sync as successful', async () => {
+    await seedHealthyPortal()
+    const customer = await seedQBCustomer()
+    // Copilot only fires delete on voided invoices. qbSyncToken differs from
+    // the mock's SyncToken to prove the delete reads the DB token, not QBO's.
+    await seedQBInvoiceSync({
+      customerId: customer.id,
+      status: InvoiceStatus.VOID,
+      qbSyncToken: '3',
+    })
+    // Non-zero tax so a dropped or mis-scaled tax column would fail the check.
+    await seedInvoiceCreatedLog({ taxAmount: '4200.00' })
+
+    const res = await postWebhook(invoiceDeletedPayload)
+    expect(res.status).toBe(200)
+
+    const deletedLogs = await db
+      .select()
+      .from(QBSyncLog)
+      .where(
+        and(
+          eq(QBSyncLog.copilotId, TEST_COPILOT_INVOICE_ID),
+          eq(QBSyncLog.eventType, EventType.DELETED),
+        ),
+      )
+    expect(deletedLogs).toHaveLength(1)
+    expect(deletedLogs[0]).toMatchObject({
+      portalId: TEST_PORTAL_ID,
+      entityType: EntityType.INVOICE,
+      eventType: EventType.DELETED,
+      status: LogStatus.SUCCESS,
+      copilotId: TEST_COPILOT_INVOICE_ID,
+      quickbooksId: TEST_QB_INVOICE_ID,
+      invoiceNumber: TEST_INVOICE_NUMBER,
+      // amount/taxAmount are carried over from the CREATED log.
+      amount: '60000.00',
+      taxAmount: '4200.00',
+      // customerName/email come from the getClient mock.
+      customerName: 'Jane Doe',
+      customerEmail: 'jane@example.com',
+    })
+
+    // Invoice sync row flipped to deleted.
+    const [invoiceSync] = await db
+      .select()
+      .from(QBInvoiceSync)
+      .where(eq(QBInvoiceSync.invoiceNumber, TEST_INVOICE_NUMBER))
+    expect(invoiceSync.status).toBe(InvoiceStatus.DELETED)
+
+    // QBO checked for the invoice, then deleted once with the mapped id + token.
+    expect(apis.intuit.getInvoice).toHaveBeenCalledTimes(1)
+    expect(apis.intuit.deleteInvoice).toHaveBeenCalledTimes(1)
+    const [deletePayload] = apis.intuit.deleteInvoice.mock.calls[0]
+    expect(deletePayload).toMatchObject({
+      Id: TEST_QB_INVOICE_ID,
+      SyncToken: '3',
+    })
+  })
+})

--- a/test/integration/quickbooks/invoiceDeleted/idempotency.test.ts
+++ b/test/integration/quickbooks/invoiceDeleted/idempotency.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { and, eq } from 'drizzle-orm'
+
+import { db } from '@/db'
+import { QBSyncLog } from '@/db/schema/qbSyncLogs'
+import { EntityType, EventType, LogStatus } from '@/app/api/core/types/log'
+
+import { invoiceDeletedPayload } from '@test/fixtures/invoiceDeleted.webhook'
+import {
+  seedHealthyPortal,
+  TEST_PORTAL_ID,
+  TEST_INVOICE_NUMBER,
+  TEST_COPILOT_INVOICE_ID,
+  TEST_QB_INVOICE_ID,
+} from '@test/helpers/seed'
+import { setupInvoiceDeletedTest } from '@test/helpers/invoiceDeletedTestSetup'
+import { postWebhook } from '@test/helpers/webhook'
+
+describe('POST /api/quickbooks/webhook — invoice.deleted (same webhook delivered twice)', () => {
+  const apis = setupInvoiceDeletedTest()
+
+  it('processes the delete only once when a deleted log for the invoice already exists', async () => {
+    // The claim conflict short-circuits early; only portal + DELETED log are needed.
+    await seedHealthyPortal()
+
+    // Simulate a prior successful delivery of this invoice's delete.
+    await db.insert(QBSyncLog).values({
+      portalId: TEST_PORTAL_ID,
+      entityType: EntityType.INVOICE,
+      eventType: EventType.DELETED,
+      status: LogStatus.SUCCESS,
+      copilotId: TEST_COPILOT_INVOICE_ID,
+      invoiceNumber: TEST_INVOICE_NUMBER,
+      quickbooksId: TEST_QB_INVOICE_ID,
+      amount: '60000.00',
+      taxAmount: '0.00',
+    })
+
+    const res = await postWebhook(invoiceDeletedPayload)
+    expect(res.status).toBe(200)
+
+    // No new DELETED row inserted and the existing one is untouched.
+    const deletedLogs = await db
+      .select()
+      .from(QBSyncLog)
+      .where(
+        and(
+          eq(QBSyncLog.copilotId, TEST_COPILOT_INVOICE_ID),
+          eq(QBSyncLog.eventType, EventType.DELETED),
+        ),
+      )
+    expect(deletedLogs).toHaveLength(1)
+    expect(deletedLogs[0].status).toBe(LogStatus.SUCCESS)
+
+    // The claim conflicts before any QBO work happens.
+    expect(apis.intuit.getInvoice).not.toHaveBeenCalled()
+    expect(apis.intuit.deleteInvoice).not.toHaveBeenCalled()
+  })
+})

--- a/test/integration/quickbooks/invoiceDeleted/invoiceNotFound.test.ts
+++ b/test/integration/quickbooks/invoiceDeleted/invoiceNotFound.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { and, eq } from 'drizzle-orm'
+
+import { db } from '@/db'
+import { QBSyncLog } from '@/db/schema/qbSyncLogs'
+import { EntityType, EventType, LogStatus } from '@/app/api/core/types/log'
+
+import { invoiceDeletedPayload } from '@test/fixtures/invoiceDeleted.webhook'
+import { seedHealthyPortal, TEST_COPILOT_INVOICE_ID } from '@test/helpers/seed'
+import { setupInvoiceDeletedTest } from '@test/helpers/invoiceDeletedTestSetup'
+import { postWebhook } from '@test/helpers/webhook'
+
+describe('POST /api/quickbooks/webhook — invoice.deleted (in QuickBooks but never synced locally)', () => {
+  const apis = setupInvoiceDeletedTest()
+
+  it('records a FAILED deleted log and deletes nothing when the invoice is missing from the sync table', async () => {
+    await seedHealthyPortal()
+    // QBO has the invoice (default mock) but there is no local mapping.
+
+    const res = await postWebhook(invoiceDeletedPayload)
+    expect(res.status).toBe(200)
+
+    const deletedLogs = await db
+      .select()
+      .from(QBSyncLog)
+      .where(
+        and(
+          eq(QBSyncLog.copilotId, TEST_COPILOT_INVOICE_ID),
+          eq(QBSyncLog.eventType, EventType.DELETED),
+        ),
+      )
+    expect(deletedLogs).toHaveLength(1)
+    expect(deletedLogs[0]).toMatchObject({
+      entityType: EntityType.INVOICE,
+      eventType: EventType.DELETED,
+      status: LogStatus.FAILED,
+    })
+    expect(deletedLogs[0].errorMessage).toContain(
+      'Invoice not found in sync table',
+    )
+
+    // QBO was checked, but the missing local mapping stopped the delete.
+    expect(apis.intuit.getInvoice).toHaveBeenCalledTimes(1)
+    expect(apis.intuit.deleteInvoice).not.toHaveBeenCalled()
+  })
+})

--- a/test/integration/quickbooks/invoiceDeleted/nonVoidedStatus.test.ts
+++ b/test/integration/quickbooks/invoiceDeleted/nonVoidedStatus.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { and, eq } from 'drizzle-orm'
+
+import { db } from '@/db'
+import { QBSyncLog } from '@/db/schema/qbSyncLogs'
+import { QBInvoiceSync } from '@/db/schema/qbInvoiceSync'
+import { EntityType, EventType, LogStatus } from '@/app/api/core/types/log'
+import { InvoiceStatus } from '@/app/api/core/types/invoice'
+
+import { invoiceDeletedPayload } from '@test/fixtures/invoiceDeleted.webhook'
+import {
+  seedHealthyPortal,
+  seedQBCustomer,
+  seedQBInvoiceSync,
+  TEST_INVOICE_NUMBER,
+  TEST_COPILOT_INVOICE_ID,
+} from '@test/helpers/seed'
+import { setupInvoiceDeletedTest } from '@test/helpers/invoiceDeletedTestSetup'
+import { postWebhook } from '@test/helpers/webhook'
+
+describe('POST /api/quickbooks/webhook — invoice.deleted (invoice not voided first)', () => {
+  const apis = setupInvoiceDeletedTest()
+
+  it('records a FAILED deleted log and deletes nothing when the sync row is not voided', async () => {
+    await seedHealthyPortal()
+    const customer = await seedQBCustomer()
+    // Still open — Copilot should only fire delete on voided invoices.
+    await seedQBInvoiceSync({
+      customerId: customer.id,
+      status: InvoiceStatus.OPEN,
+    })
+
+    const res = await postWebhook(invoiceDeletedPayload)
+    expect(res.status).toBe(200)
+
+    const deletedLogs = await db
+      .select()
+      .from(QBSyncLog)
+      .where(
+        and(
+          eq(QBSyncLog.copilotId, TEST_COPILOT_INVOICE_ID),
+          eq(QBSyncLog.eventType, EventType.DELETED),
+        ),
+      )
+    expect(deletedLogs).toHaveLength(1)
+    expect(deletedLogs[0]).toMatchObject({
+      entityType: EntityType.INVOICE,
+      eventType: EventType.DELETED,
+      status: LogStatus.FAILED,
+    })
+    expect(deletedLogs[0].errorMessage).toContain('non-voided record')
+
+    expect(apis.intuit.deleteInvoice).not.toHaveBeenCalled()
+
+    // Sync row status is unchanged.
+    const [invoiceSync] = await db
+      .select()
+      .from(QBInvoiceSync)
+      .where(eq(QBInvoiceSync.invoiceNumber, TEST_INVOICE_NUMBER))
+    expect(invoiceSync.status).toBe(InvoiceStatus.OPEN)
+  })
+})

--- a/test/integration/quickbooks/invoiceDeleted/nonVoidedStatus.test.ts
+++ b/test/integration/quickbooks/invoiceDeleted/nonVoidedStatus.test.ts
@@ -50,6 +50,8 @@ describe('POST /api/quickbooks/webhook — invoice.deleted (invoice not voided f
     })
     expect(deletedLogs[0].errorMessage).toContain('non-voided record')
 
+    // QBO is checked before the status guard, but nothing is deleted.
+    expect(apis.intuit.getInvoice).toHaveBeenCalledTimes(1)
     expect(apis.intuit.deleteInvoice).not.toHaveBeenCalled()
 
     // Sync row status is unchanged.

--- a/test/integration/quickbooks/invoiceDeleted/qboAbsentNoMapping.test.ts
+++ b/test/integration/quickbooks/invoiceDeleted/qboAbsentNoMapping.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest'
+import { and, eq } from 'drizzle-orm'
+
+import { db } from '@/db'
+import { QBSyncLog } from '@/db/schema/qbSyncLogs'
+import { QBInvoiceSync } from '@/db/schema/qbInvoiceSync'
+import { EventType, LogStatus } from '@/app/api/core/types/log'
+
+import { invoiceDeletedPayload } from '@test/fixtures/invoiceDeleted.webhook'
+import {
+  seedHealthyPortal,
+  TEST_INVOICE_NUMBER,
+  TEST_COPILOT_INVOICE_ID,
+} from '@test/helpers/seed'
+import { createMockIntuitAPI } from '@test/helpers/mocks'
+import { setupInvoiceDeletedTest } from '@test/helpers/invoiceDeletedTestSetup'
+import { postWebhook } from '@test/helpers/webhook'
+
+describe('POST /api/quickbooks/webhook — invoice.deleted (never synced, also gone from QuickBooks)', () => {
+  const apis = setupInvoiceDeletedTest(() => ({
+    intuit: createMockIntuitAPI({
+      getInvoice: vi.fn().mockResolvedValue(null),
+    }),
+  }))
+
+  it('records a soft-deleted SUCCESS log and touches nothing when there is no mapping or QBO invoice', async () => {
+    await seedHealthyPortal()
+    // No invoice sync row and nothing in QBO — nothing to delete anywhere.
+
+    const res = await postWebhook(invoiceDeletedPayload)
+    expect(res.status).toBe(200)
+
+    expect(apis.intuit.getInvoice).toHaveBeenCalledTimes(1)
+    expect(apis.intuit.deleteInvoice).not.toHaveBeenCalled()
+
+    // No sync row was created.
+    const invoiceSyncRows = await db
+      .select()
+      .from(QBInvoiceSync)
+      .where(eq(QBInvoiceSync.invoiceNumber, TEST_INVOICE_NUMBER))
+    expect(invoiceSyncRows).toHaveLength(0)
+
+    // DELETED event recorded for audit, amount from the payload.
+    const deletedLogs = await db
+      .select()
+      .from(QBSyncLog)
+      .where(
+        and(
+          eq(QBSyncLog.copilotId, TEST_COPILOT_INVOICE_ID),
+          eq(QBSyncLog.eventType, EventType.DELETED),
+        ),
+      )
+    const successLog = deletedLogs.find((l) => l.status === LogStatus.SUCCESS)
+    expect(successLog).toBeDefined()
+    expect(successLog?.deletedAt).not.toBeNull()
+    expect(successLog?.amount).toBe('60000.00')
+    // This path records neither a QuickBooks id nor tax.
+    expect(successLog?.quickbooksId).toBeNull()
+    expect(successLog?.taxAmount).toBeNull()
+  })
+})

--- a/test/integration/quickbooks/invoiceDeleted/qboAbsentWithMapping.test.ts
+++ b/test/integration/quickbooks/invoiceDeleted/qboAbsentWithMapping.test.ts
@@ -65,8 +65,9 @@ describe('POST /api/quickbooks/webhook — invoice.deleted (invoice already gone
     expect(successLog).toBeDefined()
     expect(successLog?.deletedAt).not.toBeNull()
     expect(successLog?.amount).toBe('60000.00')
-    // No QBO delete happened, so no QuickBooks id is recorded.
+    // No QBO delete happened, so no QuickBooks id or tax is recorded.
     expect(successLog?.quickbooksId).toBeNull()
+    expect(successLog?.taxAmount).toBeNull()
 
     // The prior CREATED log was soft-deleted too.
     const [createdLog] = await db

--- a/test/integration/quickbooks/invoiceDeleted/qboAbsentWithMapping.test.ts
+++ b/test/integration/quickbooks/invoiceDeleted/qboAbsentWithMapping.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest'
+import { and, eq } from 'drizzle-orm'
+
+import { db } from '@/db'
+import { QBSyncLog } from '@/db/schema/qbSyncLogs'
+import { QBInvoiceSync } from '@/db/schema/qbInvoiceSync'
+import { EventType, LogStatus } from '@/app/api/core/types/log'
+import { InvoiceStatus } from '@/app/api/core/types/invoice'
+
+import { invoiceDeletedPayload } from '@test/fixtures/invoiceDeleted.webhook'
+import {
+  seedHealthyPortal,
+  seedQBCustomer,
+  seedQBInvoiceSync,
+  seedInvoiceCreatedLog,
+  TEST_INVOICE_NUMBER,
+  TEST_COPILOT_INVOICE_ID,
+} from '@test/helpers/seed'
+import { createMockIntuitAPI } from '@test/helpers/mocks'
+import { setupInvoiceDeletedTest } from '@test/helpers/invoiceDeletedTestSetup'
+import { postWebhook } from '@test/helpers/webhook'
+
+describe('POST /api/quickbooks/webhook — invoice.deleted (invoice already gone from QuickBooks)', () => {
+  // QBO has no such invoice (never synced or deleted there directly).
+  const apis = setupInvoiceDeletedTest(() => ({
+    intuit: createMockIntuitAPI({
+      getInvoice: vi.fn().mockResolvedValue(null),
+    }),
+  }))
+
+  it('soft-deletes prior logs and marks the mapping deleted without calling QuickBooks', async () => {
+    await seedHealthyPortal()
+    const customer = await seedQBCustomer()
+    await seedQBInvoiceSync({
+      customerId: customer.id,
+      status: InvoiceStatus.VOID,
+    })
+    await seedInvoiceCreatedLog()
+
+    const res = await postWebhook(invoiceDeletedPayload)
+    expect(res.status).toBe(200)
+
+    // QBO was checked, but there was nothing to delete there.
+    expect(apis.intuit.getInvoice).toHaveBeenCalledTimes(1)
+    expect(apis.intuit.deleteInvoice).not.toHaveBeenCalled()
+
+    // Local mapping marked deleted.
+    const [invoiceSync] = await db
+      .select()
+      .from(QBInvoiceSync)
+      .where(eq(QBInvoiceSync.invoiceNumber, TEST_INVOICE_NUMBER))
+    expect(invoiceSync.status).toBe(InvoiceStatus.DELETED)
+
+    // A SUCCESS DELETED log is recorded for audit, already soft-deleted.
+    const deletedLogs = await db
+      .select()
+      .from(QBSyncLog)
+      .where(
+        and(
+          eq(QBSyncLog.copilotId, TEST_COPILOT_INVOICE_ID),
+          eq(QBSyncLog.eventType, EventType.DELETED),
+        ),
+      )
+    const successLog = deletedLogs.find((l) => l.status === LogStatus.SUCCESS)
+    expect(successLog).toBeDefined()
+    expect(successLog?.deletedAt).not.toBeNull()
+    expect(successLog?.amount).toBe('60000.00')
+    // No QBO delete happened, so no QuickBooks id is recorded.
+    expect(successLog?.quickbooksId).toBeNull()
+
+    // The prior CREATED log was soft-deleted too.
+    const [createdLog] = await db
+      .select()
+      .from(QBSyncLog)
+      .where(
+        and(
+          eq(QBSyncLog.copilotId, TEST_COPILOT_INVOICE_ID),
+          eq(QBSyncLog.eventType, EventType.CREATED),
+        ),
+      )
+    expect(createdLog.deletedAt).not.toBeNull()
+  })
+})


### PR DESCRIPTION
## OUT-3922 — integration tests for `invoice.deleted` webhook event

> Based on `OUT-3921`. Merge that PR first (or this rebases onto master once it lands).

Adds integration coverage for the `invoice.deleted` handler, focusing on the branches unique to deletion.

### Tests (6 files, `test/integration/quickbooks/invoiceDeleted/`)
Drives the real route via `next-test-api-route-handler`. Branches covered:
- **happy path** — QB invoice deleted, sync row → `DELETED`, SUCCESS log (stores the QBO **Invoice** id, amount/tax carried from the CREATED log, customer info); asserts the delete payload uses the DB-stored sync token
- **QBO-absent + local mapping** — soft-deletes prior logs, marks the mapping `DELETED`, writes a soft-deleted SUCCESS audit log; no QB call
- **QBO-absent + no mapping** — soft-deleted SUCCESS audit log (amount from payload), no sync row created
- **invoice missing from sync table** (present in QBO) → FAILED log
- **non-voided status** → FAILED log, status unchanged
- **idempotent re-delivery** — claim conflict skips before any QBO call

Added default `getInvoice`/`deleteInvoice` Intuit mocks, a `setupInvoiceDeletedTest` helper, and an `invoiceDeleted.webhook` fixture.

### Scope
Created-log missing/pending and null-`qbInvoiceId` are intentionally not covered here — they exercise the shared `getCreatedInvoiceLogOrThrow` / `buildDestructivePayloadOrThrow` helpers already covered by the `invoice.voided` suite (OUT-3921).

### Verification
- Full suite green (unit + integration via testcontainers Postgres).
- eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
