### PR TITLE
OUT-3874: use invoice address to designate tax jurisdiction

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-time-ago": "^7.3.3",
     "supabase": "2.84.4",
     "swr": "^2.3.3",
+    "us-state-converter": "^1.0.8",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/src/app/api/quickbooks/invoice/invoice.service.ts
+++ b/src/app/api/quickbooks/invoice/invoice.service.ts
@@ -729,17 +729,15 @@ export class InvoiceService extends BaseService {
     const addressPayload =
       invoiceResource.address?.postalCode && countrySubDivisionCode
         ? {
-            Line1: invoiceResource.address.addressLine1,
+            Line1:
+              invoiceResource.address.addressLine1 ||
+              invoiceResource.address.addressLine2,
             City: invoiceResource.address.city,
             CountrySubDivisionCode: countrySubDivisionCode,
             PostalCode: invoiceResource.address.postalCode,
             Country: invoiceResource.address.country,
           }
         : null
-
-    // TODO: tax-exempt invoices also have totalTax === 0 and currently fall
-    // into QBO-computes; gate on an explicit exempt flag when that's needed.
-    const overrideTax = totalTax > 0 || !addressPayload
 
     const buildPayload = (resolvedDocNumber: string) => ({
       Line: lineItems,
@@ -749,11 +747,9 @@ export class InvoiceService extends BaseService {
       DocNumber: resolvedDocNumber,
       PrivateNote: formatAssemblyInvoicePrivateNote(assemblyInvoiceNumber),
       // include tax and dates
-      ...(overrideTax && {
-        TxnTaxDetail: {
-          TotalTax: totalTax,
-        },
-      }),
+      TxnTaxDetail: {
+        TotalTax: totalTax, // Always override tax total. Address tax jurisdiction is only for report purpose. We dont actually calculate tax with address.
+      },
       ...(invoiceResource?.sentDate && {
         TxnDate: dayjs(invoiceResource.sentDate).format('YYYY/MM/DD'), // Valid date format for TxnDate is YYYY/MM/DD. For more info: https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/invoice#the-invoice-object
       }),
@@ -820,9 +816,7 @@ export class InvoiceService extends BaseService {
     }
 
     // update/ create the record in sync log table
-    const totalWithTax =
-      invoiceRes.Invoice.TotalAmt ?? actualTotalAmount + totalTax
-    const taxForLog = invoiceRes.Invoice.TxnTaxDetail?.TotalTax ?? totalTax
+    const totalWithTax = actualTotalAmount + totalTax
     await this.logSync(
       invoiceResource.id,
       {
@@ -832,7 +826,7 @@ export class InvoiceService extends BaseService {
       EventType.CREATED,
       {
         amount: (totalWithTax * 100).toFixed(2),
-        taxAmount: (taxForLog * 100).toFixed(2), // convert to cents for logs
+        taxAmount: (totalTax * 100).toFixed(2), // convert to cents for logs
         customerName: recipientInfo.displayName,
         customerEmail: recipientInfo.email,
       },
@@ -867,7 +861,7 @@ export class InvoiceService extends BaseService {
         {
           invoiceNumber: invoiceResource.number,
           invoiceId: invoiceResource.id,
-          taxAmount: (taxForLog * 100).toFixed(2),
+          taxAmount: (totalTax * 100).toFixed(2),
         },
         {
           displayName: recipientInfo.displayName,

--- a/src/app/api/quickbooks/invoice/invoice.service.ts
+++ b/src/app/api/quickbooks/invoice/invoice.service.ts
@@ -41,13 +41,13 @@ import {
   QBDestructiveInvoicePayloadSchema,
   QBNameValueSchemaType,
   QBInvoiceLineItemSchemaType,
+  QBInvoiceResponseType,
 } from '@/type/dto/intuitAPI.dto'
 import {
   InvoiceCreatedResponseType,
-  InvoiceDeletedResponse,
+  InvoiceDestructiveResponse,
   InvoiceLineItemSchemaType,
   InvoiceResponseType,
-  InvoiceVoidedResponse,
 } from '@/type/dto/webhook.dto'
 import { bottleneck } from '@/utils/bottleneck'
 import { CopilotAPI } from '@/utils/copilotAPI'
@@ -60,6 +60,7 @@ import { z } from 'zod'
 import { addSyncBreadcrumb, captureSyncError } from '@/utils/sentry'
 import { replaceSpecialCharsForQB, truncateForQB } from '@/utils/string'
 import { AccountTypeObj } from '@/constant/qbConnection'
+import { getUsStateCode } from '@/utils/common'
 
 type OneOffItemType = {
   name?: string
@@ -720,6 +721,28 @@ export class InvoiceService extends BaseService {
     const billEmailAddress =
       customer?.PrimaryEmailAddr?.Address || existingCustomer?.email
 
+    const countrySubDivisionCode = getUsStateCode(
+      invoiceResource.address?.region,
+    )
+
+    // State + postal code are the two fields QBO needs to resolve a sales-tax
+    // jurisdiction; without both it falls back to a coarser rate, so only send
+    // the address when both are present.
+    const addressPayload =
+      invoiceResource.address?.postalCode && countrySubDivisionCode
+        ? {
+            Line1: invoiceResource.address.addressLine1,
+            City: invoiceResource.address.city,
+            CountrySubDivisionCode: countrySubDivisionCode,
+            PostalCode: invoiceResource.address.postalCode,
+            Country: invoiceResource.address.country,
+          }
+        : null
+
+    // TODO: tax-exempt invoices also have totalTax === 0 and currently fall
+    // into QBO-computes; gate on an explicit exempt flag when that's needed.
+    const overrideTax = totalTax > 0 || !addressPayload
+
     const buildPayload = (resolvedDocNumber: string) => ({
       Line: lineItems,
       CustomerRef: {
@@ -728,9 +751,11 @@ export class InvoiceService extends BaseService {
       DocNumber: resolvedDocNumber,
       PrivateNote: formatAssemblyInvoicePrivateNote(assemblyInvoiceNumber),
       // include tax and dates
-      TxnTaxDetail: {
-        TotalTax: totalTax,
-      },
+      ...(overrideTax && {
+        TxnTaxDetail: {
+          TotalTax: totalTax,
+        },
+      }),
       ...(invoiceResource?.sentDate && {
         TxnDate: dayjs(invoiceResource.sentDate).format('YYYY/MM/DD'), // Valid date format for TxnDate is YYYY/MM/DD. For more info: https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/invoice#the-invoice-object
       }),
@@ -740,6 +765,10 @@ export class InvoiceService extends BaseService {
       BillEmail: {
         Address: billEmailAddress,
       },
+      ...(addressPayload && {
+        BillAddr: addressPayload,
+        ShipAddr: addressPayload,
+      }),
     })
 
     // 6. create invoice in QB
@@ -748,7 +777,7 @@ export class InvoiceService extends BaseService {
       docNumber,
     })
 
-    let invoiceRes
+    let invoiceRes: QBInvoiceResponseType
     try {
       invoiceRes = await intuitApiService.createInvoice(buildPayload(docNumber))
     } catch (err) {
@@ -793,7 +822,9 @@ export class InvoiceService extends BaseService {
     }
 
     // update/ create the record in sync log table
-    const totalWithTax = actualTotalAmount + totalTax
+    const totalWithTax =
+      invoiceRes.Invoice.TotalAmt ?? actualTotalAmount + totalTax
+    const taxForLog = invoiceRes.Invoice.TxnTaxDetail?.TotalTax ?? totalTax
     await this.logSync(
       invoiceResource.id,
       {
@@ -803,7 +834,7 @@ export class InvoiceService extends BaseService {
       EventType.CREATED,
       {
         amount: (totalWithTax * 100).toFixed(2),
-        taxAmount: (totalTax * 100).toFixed(2), // convert to cents for logs
+        taxAmount: (taxForLog * 100).toFixed(2), // convert to cents for logs
         customerName: recipientInfo.displayName,
         customerEmail: recipientInfo.email,
       },
@@ -838,7 +869,7 @@ export class InvoiceService extends BaseService {
         {
           invoiceNumber: invoiceResource.number,
           invoiceId: invoiceResource.id,
-          taxAmount: (totalTax * 100).toFixed(2),
+          taxAmount: (taxForLog * 100).toFixed(2),
         },
         {
           displayName: recipientInfo.displayName,
@@ -967,7 +998,7 @@ export class InvoiceService extends BaseService {
   }
 
   async webhookInvoiceVoided(
-    payload: InvoiceVoidedResponse,
+    payload: InvoiceDestructiveResponse,
     qbTokenInfo: IntuitAPITokensType,
   ): Promise<void> {
     addSyncBreadcrumb('Invoice voided flow started', {
@@ -1058,7 +1089,7 @@ export class InvoiceService extends BaseService {
   }
 
   async handleInvoiceDeleted(
-    payload: InvoiceDeletedResponse,
+    payload: InvoiceDestructiveResponse,
     qbTokenInfo: IntuitAPITokensType,
   ): Promise<void> {
     addSyncBreadcrumb('Invoice deleted flow started', {

--- a/src/app/api/quickbooks/invoice/invoice.service.ts
+++ b/src/app/api/quickbooks/invoice/invoice.service.ts
@@ -725,9 +725,7 @@ export class InvoiceService extends BaseService {
       invoiceResource.address?.region,
     )
 
-    // State + postal code are the two fields QBO needs to resolve a sales-tax
-    // jurisdiction; without both it falls back to a coarser rate, so only send
-    // the address when both are present.
+    // QBO needs both state and postal code to resolve a tax jurisdiction.
     const addressPayload =
       invoiceResource.address?.postalCode && countrySubDivisionCode
         ? {

--- a/src/app/api/quickbooks/webhook/webhook.service.ts
+++ b/src/app/api/quickbooks/webhook/webhook.service.ts
@@ -11,7 +11,7 @@ import { SyncLogService } from '@/app/api/quickbooks/syncLog/syncLog.service'
 import { QBSyncLog } from '@/db/schema/qbSyncLogs'
 import {
   InvoiceCreatedResponseSchema,
-  InvoiceDeletedResponseSchema,
+  InvoiceDestructiveResponseSchema,
   InvoiceResponseSchema,
   PaymentSucceededResponseSchema,
   ProductCreatedResponseSchema,
@@ -259,7 +259,7 @@ export class WebhookService extends BaseService {
     payload: unknown,
     qbTokenInfo: IntuitAPITokensType,
   ) {
-    const parsedPayload = InvoiceDeletedResponseSchema.safeParse(payload)
+    const parsedPayload = InvoiceDestructiveResponseSchema.safeParse(payload)
     if (!parsedPayload.success) {
       throw new APIError(
         httpStatus.BAD_REQUEST,

--- a/src/type/common.ts
+++ b/src/type/common.ts
@@ -1,7 +1,7 @@
 import { InvoiceStatus, PaymentStatus } from '@/app/api/core/types/invoice'
 import { ProductStatus } from '@/app/api/core/types/product'
 import { AccountTypeObj } from '@/constant/qbConnection'
-import { InvoiceLineItemSchema } from '@/type/dto/webhook.dto'
+import { AddressSchema, InvoiceLineItemSchema } from '@/type/dto/webhook.dto'
 import { SQL } from 'drizzle-orm'
 import { z } from 'zod'
 
@@ -367,18 +367,7 @@ export const InvoiceResponseSchema = z.object({
   taxAmount: z.number().default(0).nullable(),
   sentDate: z.string().datetime().nullish(),
   dueDate: z.string().datetime().nullish(),
-  // Sub-fields are individually optional: REST fetch paths (_getInvoice /
-  // _getInvoices) parse with .parse() and would throw on a partial address,
-  // aborting bulk resync. BillAddr/ShipAddr are only built when present.
-  address: z
-    .object({
-      addressLine1: z.string().optional(),
-      city: z.string().optional(),
-      country: z.string().optional(),
-      region: z.string().optional(),
-      postalCode: z.string().optional(),
-    })
-    .optional(),
+  address: AddressSchema.optional(),
   paymentMethodPreferences: z.array(
     z.object({
       type: z.string(),

--- a/src/type/common.ts
+++ b/src/type/common.ts
@@ -367,6 +367,18 @@ export const InvoiceResponseSchema = z.object({
   taxAmount: z.number().default(0).nullable(),
   sentDate: z.string().datetime().nullish(),
   dueDate: z.string().datetime().nullish(),
+  // Sub-fields are individually optional: REST fetch paths (_getInvoice /
+  // _getInvoices) parse with .parse() and would throw on a partial address,
+  // aborting bulk resync. BillAddr/ShipAddr are only built when present.
+  address: z
+    .object({
+      addressLine1: z.string().optional(),
+      city: z.string().optional(),
+      country: z.string().optional(),
+      region: z.string().optional(),
+      postalCode: z.string().optional(),
+    })
+    .optional(),
   paymentMethodPreferences: z.array(
     z.object({
       type: z.string(),

--- a/src/type/dto/intuitAPI.dto.ts
+++ b/src/type/dto/intuitAPI.dto.ts
@@ -300,6 +300,11 @@ export const QBInvoiceRowSchema = z.object({
   DueDate: z.string().optional(),
   PrivateNote: z.string().optional(),
   CustomerRef: QBNameValueSchema.optional(),
+  TxnTaxDetail: z
+    .object({
+      TotalTax: z.number(),
+    })
+    .optional(),
 })
 export type QBInvoiceRowType = z.infer<typeof QBInvoiceRowSchema>
 

--- a/src/type/dto/intuitAPI.dto.ts
+++ b/src/type/dto/intuitAPI.dto.ts
@@ -300,11 +300,6 @@ export const QBInvoiceRowSchema = z.object({
   DueDate: z.string().optional(),
   PrivateNote: z.string().optional(),
   CustomerRef: QBNameValueSchema.optional(),
-  TxnTaxDetail: z
-    .object({
-      TotalTax: z.number(),
-    })
-    .optional(),
 })
 export type QBInvoiceRowType = z.infer<typeof QBInvoiceRowSchema>
 

--- a/src/type/dto/webhook.dto.ts
+++ b/src/type/dto/webhook.dto.ts
@@ -38,6 +38,18 @@ export const InvoiceCreatedResponseSchema = z.object({
     taxAmount: z.number().default(0).nullable(),
     sentDate: z.string().datetime().nullish(),
     dueDate: z.string().datetime().nullish(),
+    // Sub-fields are individually optional: REST fetch paths (_getInvoice /
+    // _getInvoices) parse with .parse() and would throw on a partial address,
+    // aborting bulk resync. BillAddr/ShipAddr are only built when present.
+    address: z
+      .object({
+        addressLine1: z.string().optional(),
+        city: z.string().optional(),
+        country: z.string().optional(),
+        region: z.string().optional(),
+        postalCode: z.string().optional(),
+      })
+      .optional(),
     paymentMethodPreferences: z
       .array(
         z.object({
@@ -53,7 +65,7 @@ export type InvoiceCreatedResponseType = z.infer<
   typeof InvoiceCreatedResponseSchema
 >
 
-export const InvoiceDeletedResponseSchema = z.object({
+export const InvoiceDestructiveResponseSchema = z.object({
   id: z.string(),
   number: z.string(),
   total: z.number(),
@@ -61,18 +73,9 @@ export const InvoiceDeletedResponseSchema = z.object({
   clientId: z.string().uuid().or(z.literal('')), // allow uuid or empty string
   companyId: z.string().uuid().or(z.literal('')), // allow uuid or empty string
 })
-export type InvoiceDeletedResponse = z.infer<
-  typeof InvoiceDeletedResponseSchema
+export type InvoiceDestructiveResponse = z.infer<
+  typeof InvoiceDestructiveResponseSchema
 >
-
-export const InvoiceVoidedResponseSchema = z.object({
-  id: z.string(),
-  number: z.string(),
-  total: z.number(),
-  clientId: z.string().uuid().or(z.literal('')), // allow uuid or empty string
-  companyId: z.string().uuid().or(z.literal('')), // allow uuid or empty string
-})
-export type InvoiceVoidedResponse = z.infer<typeof InvoiceDeletedResponseSchema>
 
 /** Product */
 export const ProductCreatedResponseSchema = z.object({

--- a/src/type/dto/webhook.dto.ts
+++ b/src/type/dto/webhook.dto.ts
@@ -24,6 +24,16 @@ export const InvoiceLineItemSchema = z.object({
 
 export type InvoiceLineItemSchemaType = z.infer<typeof InvoiceLineItemSchema>
 
+// Shared by the webhook and REST invoice payloads. Sub-fields are optional so
+// a partial address doesn't throw on the REST .parse() paths.
+export const AddressSchema = z.object({
+  addressLine1: z.string().optional(),
+  city: z.string().optional(),
+  country: z.string().optional(),
+  region: z.string().optional(),
+  postalCode: z.string().optional(),
+})
+
 export const InvoiceCreatedResponseSchema = z.object({
   data: z.object({
     id: z.string(),
@@ -38,18 +48,7 @@ export const InvoiceCreatedResponseSchema = z.object({
     taxAmount: z.number().default(0).nullable(),
     sentDate: z.string().datetime().nullish(),
     dueDate: z.string().datetime().nullish(),
-    // Sub-fields are individually optional: REST fetch paths (_getInvoice /
-    // _getInvoices) parse with .parse() and would throw on a partial address,
-    // aborting bulk resync. BillAddr/ShipAddr are only built when present.
-    address: z
-      .object({
-        addressLine1: z.string().optional(),
-        city: z.string().optional(),
-        country: z.string().optional(),
-        region: z.string().optional(),
-        postalCode: z.string().optional(),
-      })
-      .optional(),
+    address: AddressSchema.optional(),
     paymentMethodPreferences: z
       .array(
         z.object({

--- a/src/type/dto/webhook.dto.ts
+++ b/src/type/dto/webhook.dto.ts
@@ -28,6 +28,7 @@ export type InvoiceLineItemSchemaType = z.infer<typeof InvoiceLineItemSchema>
 // a partial address doesn't throw on the REST .parse() paths.
 export const AddressSchema = z.object({
   addressLine1: z.string().optional(),
+  addressLine2: z.string().optional(),
   city: z.string().optional(),
   country: z.string().optional(),
   region: z.string().optional(),

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -26,8 +26,9 @@ export const getTimeInterval = (interval: string, intervalCount: number) => {
 export const getUsStateCode = (state?: string): string | null => {
   const fullStateName = state?.trim()
   if (!fullStateName) return null
-  // abbr() returns a >2-char sentence when the name isn't a known US state.
+  // abbr() returns a sentence when the name isn't a known US state; a valid
+  // USPS code is always exactly 2 chars, so reject anything else.
   const abbreviation = abbr(fullStateName)
-  if (abbreviation.length > 2) return null
+  if (abbreviation.length !== 2) return null
   return abbreviation
 }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -26,8 +26,7 @@ export const getTimeInterval = (interval: string, intervalCount: number) => {
 export const getUsStateCode = (state?: string): string | null => {
   const fullStateName = state?.trim()
   if (!fullStateName) return null
-  // abbr() returns a sentence when the name isn't a known US state; a valid
-  // USPS code is always exactly 2 chars, so reject anything else.
+  // A valid USPS code is exactly 2 chars; abbr() returns a sentence otherwise.
   const abbreviation = abbr(fullStateName)
   if (abbreviation.length !== 2) return null
   return abbreviation

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,4 +1,5 @@
 import { TimeInterval } from '@/type/copilot'
+import { abbr } from 'us-state-converter'
 
 export const getTimeInterval = (interval: string, intervalCount: number) => {
   switch (interval) {
@@ -20,4 +21,13 @@ export const getTimeInterval = (interval: string, intervalCount: number) => {
     default:
       return TimeInterval.MONTHLY
   }
+}
+
+export const getUsStateCode = (state?: string): string | null => {
+  const fullStateName = state?.trim()
+  if (!fullStateName) return null
+  // abbr() returns a >2-char sentence when the name isn't a known US state.
+  const abbreviation = abbr(fullStateName)
+  if (abbreviation.length > 2) return null
+  return abbreviation
 }

--- a/test/fixtures/invoiceDeleted.webhook.ts
+++ b/test/fixtures/invoiceDeleted.webhook.ts
@@ -1,6 +1,6 @@
 import type { z } from 'zod'
 
-import { InvoiceDeletedResponseSchema } from '@/type/dto/webhook.dto'
+import { InvoiceDestructiveResponseSchema } from '@/type/dto/webhook.dto'
 import {
   TEST_CLIENT_ID,
   TEST_COPILOT_INVOICE_ID,
@@ -14,7 +14,7 @@ type Envelope = {
 
 // Deleted is dispatched as `payload.data` and parsed flat (no status/tax).
 type InvoiceDeletedFixture = Envelope & {
-  data: z.input<typeof InvoiceDeletedResponseSchema>
+  data: z.input<typeof InvoiceDestructiveResponseSchema>
 }
 
 export const invoiceDeletedPayload: InvoiceDeletedFixture = {

--- a/test/integration/quickbooks/invoiceCreated/addressTaxJurisdiction.test.ts
+++ b/test/integration/quickbooks/invoiceCreated/addressTaxJurisdiction.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from 'vitest'
+import { eq } from 'drizzle-orm'
+
+import { db } from '@/db'
+import { QBSyncLog } from '@/db/schema/qbSyncLogs'
+
+import invoiceCreatedPayload from '@test/fixtures/invoiceCreated.webhook'
+import {
+  seedHealthyPortal,
+  seedProductSync,
+  TEST_COPILOT_INVOICE_ID,
+  TEST_QB_INVOICE_ID,
+} from '@test/helpers/seed'
+import { createMockIntuitAPI } from '@test/helpers/mocks'
+import { setupInvoiceCreatedTest } from '@test/helpers/invoiceCreatedTestSetup'
+import { postWebhook } from '@test/helpers/webhook'
+
+// A full US address as Assembly sends it (region is a full state name).
+const address = {
+  addressLine1: '1 Market St',
+  city: 'San Francisco',
+  region: 'California',
+  postalCode: '94105',
+  country: 'US',
+}
+
+// The address QBO should receive, with region mapped to its two-letter code.
+const expectedQbAddress = {
+  Line1: '1 Market St',
+  City: 'San Francisco',
+  CountrySubDivisionCode: 'CA',
+  PostalCode: '94105',
+  Country: 'US',
+}
+
+const withAddress = (extraData: Record<string, unknown> = {}) => ({
+  ...invoiceCreatedPayload,
+  data: { ...invoiceCreatedPayload.data, address, ...extraData },
+})
+
+describe('POST /api/quickbooks/webhook — invoice.created (address drives tax jurisdiction)', () => {
+  const apis = setupInvoiceCreatedTest(() => ({
+    intuit: createMockIntuitAPI({
+      getAnItem: vi
+        .fn()
+        .mockImplementation(async (_name?: string, id?: string) =>
+          id === '999'
+            ? { Id: '999', SyncToken: '0', Active: true }
+            : undefined,
+        ),
+      // QBO computes its own tax from the jurisdiction and echoes it back.
+      createInvoice: vi.fn().mockResolvedValue({
+        Invoice: {
+          Id: 'qb-inv-1',
+          SyncToken: '0',
+          TotalAmt: 630,
+          TxnTaxDetail: { TotalTax: 30 },
+        },
+      }),
+    }),
+  }))
+
+  it('sends the address as ShipAddr and BillAddr and lets QBO compute tax when Assembly tax is zero', async () => {
+    await seedHealthyPortal()
+    await seedProductSync()
+
+    const res = await postWebhook(withAddress())
+    expect(res.status).toBe(200)
+
+    const [invoicePayload] = apis.intuit.createInvoice.mock.calls[0]
+    expect(invoicePayload.ShipAddr).toEqual(expectedQbAddress)
+    expect(invoicePayload.BillAddr).toEqual(expectedQbAddress)
+    // Address present + zero Assembly tax => defer to QBO's automated sales tax.
+    expect(invoicePayload.TxnTaxDetail).toBeUndefined()
+
+    // The sync log records the tax QBO actually computed, not Assembly's zero.
+    const logs = await db
+      .select()
+      .from(QBSyncLog)
+      .where(eq(QBSyncLog.copilotId, TEST_COPILOT_INVOICE_ID))
+    expect(logs).toHaveLength(1)
+    expect(Number(logs[0].amount)).toBe(63000)
+    expect(Number(logs[0].taxAmount)).toBe(3000)
+  })
+
+  it('overrides QBO with Assembly tax when Assembly reports a non-zero tax', async () => {
+    await seedHealthyPortal()
+    await seedProductSync()
+
+    const res = await postWebhook(withAddress({ taxAmount: 30 }))
+    expect(res.status).toBe(200)
+
+    const [invoicePayload] = apis.intuit.createInvoice.mock.calls[0]
+    // Address is still sent for the record, but we force our own tax total.
+    expect(invoicePayload.ShipAddr).toEqual(expectedQbAddress)
+    expect(invoicePayload.TxnTaxDetail).toEqual({ TotalTax: 30 })
+  })
+
+  it('omits the address when the postal code is missing, since QBO needs it to resolve the jurisdiction', async () => {
+    await seedHealthyPortal()
+    await seedProductSync()
+
+    const { postalCode: _postalCode, ...addressWithoutPostalCode } = address
+    const res = await postWebhook(
+      withAddress({ address: addressWithoutPostalCode }),
+    )
+    expect(res.status).toBe(200)
+
+    const [invoicePayload] = apis.intuit.createInvoice.mock.calls[0]
+    expect(invoicePayload.ShipAddr).toBeUndefined()
+    expect(invoicePayload.BillAddr).toBeUndefined()
+    // No usable address => fall back to sending our own (zero) tax total.
+    expect(invoicePayload.TxnTaxDetail).toEqual({ TotalTax: 0 })
+  })
+
+  it('records the payment for a paid invoice using the tax-inclusive total QBO returned', async () => {
+    await seedHealthyPortal()
+    await seedProductSync()
+
+    const res = await postWebhook(withAddress({ status: 'paid' }))
+    expect(res.status).toBe(200)
+
+    expect(apis.intuit.createPayment).toHaveBeenCalledTimes(1)
+    const [paymentPayload] = apis.intuit.createPayment.mock.calls[0]
+    // 630 is QBO's tax-inclusive TotalAmt, not the locally-computed 600
+    // subtotal. Using the subtotal here would under-record the payment.
+    expect(paymentPayload.TotalAmt).toBe(630)
+    expect(paymentPayload.Line[0].Amount).toBe(630)
+    expect(paymentPayload.Line[0].LinkedTxn[0]).toMatchObject({
+      TxnId: TEST_QB_INVOICE_ID,
+      TxnType: 'Invoice',
+    })
+  })
+})

--- a/test/integration/quickbooks/invoiceCreated/addressTaxJurisdiction.test.ts
+++ b/test/integration/quickbooks/invoiceCreated/addressTaxJurisdiction.test.ts
@@ -38,7 +38,7 @@ const withAddress = (extraData: Record<string, unknown> = {}) => ({
   data: { ...invoiceCreatedPayload.data, address, ...extraData },
 })
 
-describe('POST /api/quickbooks/webhook — invoice.created (address drives tax jurisdiction)', () => {
+describe('POST /api/quickbooks/webhook — invoice.created (customer address on the invoice)', () => {
   const apis = setupInvoiceCreatedTest(() => ({
     intuit: createMockIntuitAPI({
       getAnItem: vi
@@ -48,19 +48,10 @@ describe('POST /api/quickbooks/webhook — invoice.created (address drives tax j
             ? { Id: '999', SyncToken: '0', Active: true }
             : undefined,
         ),
-      // QBO computes its own tax from the jurisdiction and echoes it back.
-      createInvoice: vi.fn().mockResolvedValue({
-        Invoice: {
-          Id: 'qb-inv-1',
-          SyncToken: '0',
-          TotalAmt: 630,
-          TxnTaxDetail: { TotalTax: 30 },
-        },
-      }),
     }),
   }))
 
-  it('sends the address as ShipAddr and BillAddr and lets QBO compute tax when Assembly tax is zero', async () => {
+  it('sends the address as BillAddr and ShipAddr and always reports Assembly tax', async () => {
     await seedHealthyPortal()
     await seedProductSync()
 
@@ -68,22 +59,23 @@ describe('POST /api/quickbooks/webhook — invoice.created (address drives tax j
     expect(res.status).toBe(200)
 
     const [invoicePayload] = apis.intuit.createInvoice.mock.calls[0]
-    expect(invoicePayload.ShipAddr).toEqual(expectedQbAddress)
     expect(invoicePayload.BillAddr).toEqual(expectedQbAddress)
-    // Address present + zero Assembly tax => defer to QBO's automated sales tax.
-    expect(invoicePayload.TxnTaxDetail).toBeUndefined()
+    expect(invoicePayload.ShipAddr).toEqual(expectedQbAddress)
+    // Address is for the QBO record only; tax always comes from Assembly, so
+    // TxnTaxDetail is sent even when the amount is zero.
+    expect(invoicePayload.TxnTaxDetail).toEqual({ TotalTax: 0 })
 
-    // The sync log records the tax QBO actually computed, not Assembly's zero.
+    // The sync log records Assembly's own subtotal and tax, not QBO's numbers.
     const logs = await db
       .select()
       .from(QBSyncLog)
       .where(eq(QBSyncLog.copilotId, TEST_COPILOT_INVOICE_ID))
     expect(logs).toHaveLength(1)
-    expect(Number(logs[0].amount)).toBe(63000)
-    expect(Number(logs[0].taxAmount)).toBe(3000)
+    expect(Number(logs[0].amount)).toBe(60000)
+    expect(Number(logs[0].taxAmount)).toBe(0)
   })
 
-  it('overrides QBO with Assembly tax when Assembly reports a non-zero tax', async () => {
+  it('sends Assembly non-zero tax as the invoice tax total', async () => {
     await seedHealthyPortal()
     await seedProductSync()
 
@@ -91,12 +83,11 @@ describe('POST /api/quickbooks/webhook — invoice.created (address drives tax j
     expect(res.status).toBe(200)
 
     const [invoicePayload] = apis.intuit.createInvoice.mock.calls[0]
-    // Address is still sent for the record, but we force our own tax total.
     expect(invoicePayload.ShipAddr).toEqual(expectedQbAddress)
     expect(invoicePayload.TxnTaxDetail).toEqual({ TotalTax: 30 })
   })
 
-  it('omits the address when the postal code is missing, since QBO needs it to resolve the jurisdiction', async () => {
+  it('omits the address when the postal code is missing', async () => {
     await seedHealthyPortal()
     await seedProductSync()
 
@@ -109,11 +100,11 @@ describe('POST /api/quickbooks/webhook — invoice.created (address drives tax j
     const [invoicePayload] = apis.intuit.createInvoice.mock.calls[0]
     expect(invoicePayload.ShipAddr).toBeUndefined()
     expect(invoicePayload.BillAddr).toBeUndefined()
-    // No usable address => fall back to sending our own (zero) tax total.
+    // Tax total is still sent regardless of whether the address made the cut.
     expect(invoicePayload.TxnTaxDetail).toEqual({ TotalTax: 0 })
   })
 
-  it('records the payment for a paid invoice using the tax-inclusive total QBO returned', async () => {
+  it('records the payment for a paid invoice using the invoice total', async () => {
     await seedHealthyPortal()
     await seedProductSync()
 
@@ -122,10 +113,9 @@ describe('POST /api/quickbooks/webhook — invoice.created (address drives tax j
 
     expect(apis.intuit.createPayment).toHaveBeenCalledTimes(1)
     const [paymentPayload] = apis.intuit.createPayment.mock.calls[0]
-    // 630 is QBO's tax-inclusive TotalAmt, not the locally-computed 600
-    // subtotal. Using the subtotal here would under-record the payment.
-    expect(paymentPayload.TotalAmt).toBe(630)
-    expect(paymentPayload.Line[0].Amount).toBe(630)
+    // 600 subtotal + 0 tax; both fields use the same Assembly-derived total.
+    expect(paymentPayload.TotalAmt).toBe(600)
+    expect(paymentPayload.Line[0].Amount).toBe(600)
     expect(paymentPayload.Line[0].LinkedTxn[0]).toMatchObject({
       TxnId: TEST_QB_INVOICE_ID,
       TxnType: 'Invoice',

--- a/test/unit/utils/common.test.ts
+++ b/test/unit/utils/common.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+
+import { getUsStateCode } from '@/utils/common'
+
+describe('getUsStateCode', () => {
+  it('converts a full state name to its two-letter code', () => {
+    expect(getUsStateCode('California')).toBe('CA')
+    expect(getUsStateCode('New York')).toBe('NY')
+  })
+
+  it('is case-insensitive and ignores surrounding whitespace', () => {
+    expect(getUsStateCode('  california ')).toBe('CA')
+    expect(getUsStateCode('TEXAS')).toBe('TX')
+  })
+
+  it('returns null when no state is given', () => {
+    expect(getUsStateCode(undefined)).toBeNull()
+    expect(getUsStateCode('')).toBeNull()
+    expect(getUsStateCode('   ')).toBeNull()
+  })
+
+  it('returns null for a name that is not a US state', () => {
+    expect(getUsStateCode('Ontario')).toBeNull()
+    expect(getUsStateCode('not a real place')).toBeNull()
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -6280,6 +6280,7 @@ __metadata:
     tailwindcss: "npm:^4.1.5"
     tsx: "npm:^4.21.0"
     typescript: "npm:^5.8.3"
+    us-state-converter: "npm:^1.0.8"
     vitest: "npm:^4.1.3"
     zod: "npm:^3.22.4"
   languageName: unknown
@@ -14125,6 +14126,13 @@ __metadata:
   version: 10.1.0
   resolution: "urlpattern-polyfill@npm:10.1.0"
   checksum: 10c0/5b124fd8d0ae920aa2a48b49a7a3b9ad1643b5ce7217b808fb6877826e751cabc01897fd4c85cd1989c4e729072b63aad5c3ba1c1325e4433e0d2f6329156bf1
+  languageName: node
+  linkType: hard
+
+"us-state-converter@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "us-state-converter@npm:1.0.8"
+  checksum: 10c0/2743aa213de51cd97d82a12ff13b39b5aa79c297ffaf67014986aa5f86a283683850abb0c58220b6d3744baf4ba116fd48117db43034b6816ddcea00804514e9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What & why

[OUT-3874](https://linear.app/assemblycom/issue/OUT-3874/use-address-to-designate-tax-jurisdiction) — attach the customer's address to the QuickBooks invoice so the tax jurisdiction is visible on the QBO record for reporting/review.

## Behavior

- **Tax total is always sourced from Assembly.** `TxnTaxDetail.TotalTax` is set to Assembly's computed tax on every invoice; the sync log and any created payment use Assembly's local total. QBO is **not** relied on to compute tax.
- **Customer address is sent for the QBO record**, as both `BillAddr` and `ShipAddr`, only when the two fields QBO needs for a jurisdiction — state and postal code — are present. `getUsStateCode` (via `us-state-converter`) maps a full state name to the two-letter `CountrySubDivisionCode`.
- Address sub-fields are optional (shared `AddressSchema`) so a partial address on the REST fetch paths (`_getInvoice`/`_getInvoices`, which use `.parse()`) can't abort a bulk resync.
- **Refactor**: consolidated the duplicate `InvoiceDeleted`/`InvoiceVoided` schemas into `InvoiceDestructiveResponseSchema`.

## Testing

- Full suite green (`yarn test`); `tsc` and lint clean.
- Unit tests for `getUsStateCode`; integration coverage for the address payload (`BillAddr`/`ShipAddr`), the always-sent `TxnTaxDetail`, the missing-postal-code skip, and the paid-invoice payment total.

## Open item (needs sandbox confirmation)

On realms with **Automated Sales Tax enabled**, sending `ShipAddr` may cause QBO to recompute tax from that jurisdiction and ignore the `TxnTaxDetail.TotalTax` we send — which would contradict the "address is report-only" intent. This should be verified against a QBO sandbox before relying on it; if AST overrides, we should send `BillAddr` only (lower risk) or accept QBO-computed tax deliberately. The integration tests validate the payload we send, not QBO's tax outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)