### PR TITLE
OUT-4006: land payout test suite + shared test infra

### DIFF
--- a/test/fixtures/payout.webhook.ts
+++ b/test/fixtures/payout.webhook.ts
@@ -1,0 +1,25 @@
+import { WebhookEvents } from '@/app/api/core/types/webhook'
+import { TEST_COPILOT_INVOICE_ID } from '@test/helpers/seed'
+
+// Two invoices: $200.00 + $150.00 gross, $3.75 + $2.00 fees → net $344.25 (34425 cents)
+export const payoutPayload = {
+  eventType: WebhookEvents.PAYOUT_RECONCILIATION_COMPLETED,
+  eventTime: '1713744000',
+  data: {
+    payout: {
+      id: 'po_test_1',
+      arrivalDate: 1713744000, // 2024-04-22
+      currency: 'usd',
+      netAmount: 34425,
+      status: 'paid',
+    },
+    lineItems: [
+      {
+        copilotInvoiceId: TEST_COPILOT_INVOICE_ID,
+        grossAmount: 20000,
+        feeAmount: 375,
+      },
+      { copilotInvoiceId: 'inv-cop-0002', grossAmount: 15000, feeAmount: 200 },
+    ],
+  },
+}

--- a/test/helpers/mocks.ts
+++ b/test/helpers/mocks.ts
@@ -145,6 +145,9 @@ export function createMockIntuitAPI(overrides: IntuitAPIOverrides = {}) {
     createPurchase: vi.fn().mockResolvedValue({
       Purchase: { Id: TEST_QB_PURCHASE_ID, SyncToken: '0' },
     }),
+    createDeposit: vi.fn().mockResolvedValue({
+      Deposit: { Id: 'qb-deposit-1', SyncToken: '0' },
+    }),
     deletePurchase: vi.fn().mockResolvedValue({
       Purchase: { Id: TEST_QB_PURCHASE_ID, status: 'Deleted' },
     }),

--- a/test/helpers/seed.ts
+++ b/test/helpers/seed.ts
@@ -20,6 +20,7 @@ export const TEST_REFRESH_TOKEN = 'test-refresh-token'
 export const TEST_INCOME_ACCOUNT_REF = '100'
 export const TEST_ASSET_ACCOUNT_REF = '101'
 export const TEST_EXPENSE_ACCOUNT_REF = '102'
+export const TEST_BANK_ACCOUNT_REF = '103'
 export const TEST_INTERNAL_USER_ID = 'test-internal-user-id'
 export const TEST_WEBHOOK_TOKEN = 'test-token-xyz'
 

--- a/test/integration/quickbooks/paymentSucceeded/bankDepositFlagNoOp.test.ts
+++ b/test/integration/quickbooks/paymentSucceeded/bankDepositFlagNoOp.test.ts
@@ -26,10 +26,11 @@ describe('payment.succeeded with bankDepositFeeFlag on — no per-payment deposi
     expect(apis.intuit.createDeposit).not.toHaveBeenCalled()
     expect(apis.intuit.createPurchase).not.toHaveBeenCalled()
 
+    // Handler returns before claiming, so no claim row exists at all.
     const logs = await db
       .select()
       .from(QBSyncLog)
       .where(eq(QBSyncLog.copilotId, TEST_COPILOT_PAYMENT_ID))
-    expect(logs.filter((l) => l.status === 'success')).toHaveLength(0)
+    expect(logs).toHaveLength(0)
   })
 })

--- a/test/integration/quickbooks/paymentSucceeded/bankDepositFlagNoOp.test.ts
+++ b/test/integration/quickbooks/paymentSucceeded/bankDepositFlagNoOp.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { eq } from 'drizzle-orm'
+
+import { db } from '@/db'
+import { QBSyncLog } from '@/db/schema/qbSyncLogs'
+
+import { paymentSucceededPayload } from '@test/fixtures/paymentSucceeded.webhook'
+import { seedHealthyPortal, TEST_COPILOT_PAYMENT_ID } from '@test/helpers/seed'
+import { setupPaymentSucceededTest } from '@test/helpers/paymentSucceededTestSetup'
+import { postWebhook } from '@test/helpers/webhook'
+
+describe('payment.succeeded with bankDepositFeeFlag on — no per-payment deposit', () => {
+  const apis = setupPaymentSucceededTest()
+
+  it('creates neither a deposit nor a purchase', async () => {
+    // handlePaymentSucceeded returns immediately once bankDepositFeeFlag is
+    // true (the deposit is deferred to payout.reconciliation_completed), so
+    // no invoice sync, bank account ref, or QBO calls are ever reached here.
+    await seedHealthyPortal({
+      setting: { absorbedFeeFlag: true, bankDepositFeeFlag: true },
+    })
+
+    const res = await postWebhook(paymentSucceededPayload)
+    expect(res.status).toBe(200)
+
+    expect(apis.intuit.createDeposit).not.toHaveBeenCalled()
+    expect(apis.intuit.createPurchase).not.toHaveBeenCalled()
+
+    const logs = await db
+      .select()
+      .from(QBSyncLog)
+      .where(eq(QBSyncLog.copilotId, TEST_COPILOT_PAYMENT_ID))
+    expect(logs.filter((l) => l.status === 'success')).toHaveLength(0)
+  })
+})

--- a/test/integration/quickbooks/paymentSucceeded/copilotInvoiceNotFound.test.ts
+++ b/test/integration/quickbooks/paymentSucceeded/copilotInvoiceNotFound.test.ts
@@ -47,5 +47,7 @@ describe('POST /api/quickbooks/webhook — payment.succeeded (Copilot returns no
 
     expect(apis.intuit.createPurchase).not.toHaveBeenCalled()
     expect(apis.intuit.deletePurchase).not.toHaveBeenCalled()
+    // Throw happens before any QBO round-trip, so account verification never runs.
+    expect(apis.intuit.getAnAccount).not.toHaveBeenCalled()
   })
 })

--- a/test/integration/quickbooks/paymentSucceeded/invoiceSyncNotFound.test.ts
+++ b/test/integration/quickbooks/paymentSucceeded/invoiceSyncNotFound.test.ts
@@ -36,5 +36,7 @@ describe('POST /api/quickbooks/webhook — payment.succeeded (no local invoice m
 
     expect(apis.intuit.createPurchase).not.toHaveBeenCalled()
     expect(apis.intuit.deletePurchase).not.toHaveBeenCalled()
+    // Lookup miss throws before any QBO round-trip, so account verification never runs.
+    expect(apis.intuit.getAnAccount).not.toHaveBeenCalled()
   })
 })

--- a/test/integration/quickbooks/payoutReconciliation/bankAccountDeleted.test.ts
+++ b/test/integration/quickbooks/payoutReconciliation/bankAccountDeleted.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest'
+import { eq } from 'drizzle-orm'
+
+import { db } from '@/db'
+import { QBSyncLog } from '@/db/schema/qbSyncLogs'
+import { EntityType, EventType, LogStatus } from '@/app/api/core/types/log'
+
+import { payoutPayload } from '@test/fixtures/payout.webhook'
+import {
+  seedHealthyPortal,
+  TEST_PORTAL_ID,
+  TEST_COPILOT_INVOICE_ID,
+  TEST_BANK_ACCOUNT_REF,
+  TEST_EXPENSE_ACCOUNT_REF,
+} from '@test/helpers/seed'
+import { createMockIntuitAPI } from '@test/helpers/mocks'
+import { setupPaymentSucceededTest } from '@test/helpers/paymentSucceededTestSetup'
+import { postWebhook } from '@test/helpers/webhook'
+
+describe('payout — configured bank account no longer exists in QuickBooks', () => {
+  const apis = setupPaymentSucceededTest(() => ({
+    intuit: createMockIntuitAPI({
+      // The bank ref query comes back empty (deleted in QBO); the expense
+      // ref lookup must still resolve normally.
+      getAnAccount: vi
+        .fn()
+        .mockImplementation(async (_name?: string, id?: string) => {
+          if (id === TEST_BANK_ACCOUNT_REF) return undefined
+          return {
+            Id: id,
+            Name: 'Sales of Product Income',
+            SyncToken: '0',
+            Active: true,
+          }
+        }),
+    }),
+  }))
+
+  it('aborts the deposit and logs a failed payout/settled entry asking to reselect a bank account', async () => {
+    await seedHealthyPortal({
+      portal: {
+        bankAccountRef: TEST_BANK_ACCOUNT_REF,
+        expenseAccountRef: TEST_EXPENSE_ACCOUNT_REF,
+      },
+      setting: { absorbedFeeFlag: true, bankDepositFeeFlag: true },
+    })
+    await db.insert(QBSyncLog).values([
+      {
+        portalId: TEST_PORTAL_ID,
+        copilotId: TEST_COPILOT_INVOICE_ID,
+        entityType: EntityType.INVOICE,
+        eventType: EventType.PAID,
+        status: LogStatus.SUCCESS,
+        quickbooksId: 'qbpay_A',
+      },
+      {
+        portalId: TEST_PORTAL_ID,
+        copilotId: 'inv-cop-0002',
+        entityType: EntityType.INVOICE,
+        eventType: EventType.PAID,
+        status: LogStatus.SUCCESS,
+        quickbooksId: 'qbpay_B',
+      },
+    ])
+
+    const res = await postWebhook(payoutPayload)
+    expect(res.status).toBe(200)
+
+    expect(apis.intuit.createDeposit).not.toHaveBeenCalled()
+
+    const logs = await db
+      .select()
+      .from(QBSyncLog)
+      .where(eq(QBSyncLog.copilotId, 'po_test_1'))
+    expect(logs).toHaveLength(1)
+    expect(logs[0]).toMatchObject({
+      portalId: TEST_PORTAL_ID,
+      entityType: EntityType.PAYOUT,
+      eventType: EventType.SETTLED,
+      status: LogStatus.FAILED,
+      shouldRetry: false,
+    })
+    // Pins the abort to restoreAccountRef's Bank-type throw specifically —
+    // a deleted bank account is never auto-restored/created.
+    expect(logs[0].errorMessage).toContain('reselect a bank account')
+  })
+})

--- a/test/integration/quickbooks/payoutReconciliation/bankAccountInactive.test.ts
+++ b/test/integration/quickbooks/payoutReconciliation/bankAccountInactive.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from 'vitest'
+import { eq } from 'drizzle-orm'
+
+import { db } from '@/db'
+import { QBSyncLog } from '@/db/schema/qbSyncLogs'
+import { EntityType, EventType, LogStatus } from '@/app/api/core/types/log'
+
+import { payoutPayload } from '@test/fixtures/payout.webhook'
+import {
+  seedHealthyPortal,
+  TEST_PORTAL_ID,
+  TEST_COPILOT_INVOICE_ID,
+  TEST_BANK_ACCOUNT_REF,
+  TEST_EXPENSE_ACCOUNT_REF,
+} from '@test/helpers/seed'
+import { createMockIntuitAPI } from '@test/helpers/mocks'
+import { setupPaymentSucceededTest } from '@test/helpers/paymentSucceededTestSetup'
+import { postWebhook } from '@test/helpers/webhook'
+
+describe('payout — configured bank account is inactive in QuickBooks', () => {
+  const apis = setupPaymentSucceededTest(() => ({
+    intuit: createMockIntuitAPI({
+      // Only the bank ref comes back inactive; the expense ref (queried in
+      // the same flow) must stay on the default active response so this
+      // test exercises the bank-reactivation path specifically.
+      getAnAccount: vi
+        .fn()
+        .mockImplementation(async (_name?: string, id?: string) => {
+          if (id === TEST_BANK_ACCOUNT_REF) {
+            return {
+              Id: TEST_BANK_ACCOUNT_REF,
+              Name: 'Business Checking',
+              SyncToken: '0',
+              Active: false,
+            }
+          }
+          return {
+            Id: id,
+            Name: 'Sales of Product Income',
+            SyncToken: '0',
+            Active: true,
+          }
+        }),
+      updateAccount: vi.fn().mockResolvedValue({
+        Account: {
+          Id: TEST_BANK_ACCOUNT_REF,
+          Name: 'Business Checking',
+          SyncToken: '1',
+          Active: true,
+        },
+      }),
+    }),
+  }))
+
+  it('reactivates the bank account and still creates the deposit', async () => {
+    await seedHealthyPortal({
+      portal: {
+        bankAccountRef: TEST_BANK_ACCOUNT_REF,
+        expenseAccountRef: TEST_EXPENSE_ACCOUNT_REF,
+      },
+      setting: { absorbedFeeFlag: true, bankDepositFeeFlag: true },
+    })
+    await db.insert(QBSyncLog).values([
+      {
+        portalId: TEST_PORTAL_ID,
+        copilotId: TEST_COPILOT_INVOICE_ID,
+        entityType: EntityType.INVOICE,
+        eventType: EventType.PAID,
+        status: LogStatus.SUCCESS,
+        quickbooksId: 'qbpay_A',
+      },
+      {
+        portalId: TEST_PORTAL_ID,
+        copilotId: 'inv-cop-0002',
+        entityType: EntityType.INVOICE,
+        eventType: EventType.PAID,
+        status: LogStatus.SUCCESS,
+        quickbooksId: 'qbpay_B',
+      },
+    ])
+
+    const res = await postWebhook(payoutPayload)
+    expect(res.status).toBe(200)
+
+    expect(apis.intuit.updateAccount).toHaveBeenCalledTimes(1)
+    expect(apis.intuit.updateAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Id: TEST_BANK_ACCOUNT_REF,
+        SyncToken: '0',
+        Active: true,
+      }),
+    )
+
+    expect(apis.intuit.createDeposit).toHaveBeenCalledTimes(1)
+    const [depositPayload] = apis.intuit.createDeposit.mock.calls[0]
+    expect(depositPayload.DepositToAccountRef).toEqual({
+      value: TEST_BANK_ACCOUNT_REF,
+    })
+
+    const logs = await db
+      .select()
+      .from(QBSyncLog)
+      .where(eq(QBSyncLog.copilotId, 'po_test_1'))
+    expect(logs).toHaveLength(1)
+    expect(logs[0]).toMatchObject({
+      portalId: TEST_PORTAL_ID,
+      entityType: EntityType.PAYOUT,
+      eventType: EventType.SETTLED,
+      status: LogStatus.SUCCESS,
+    })
+  })
+})

--- a/test/integration/quickbooks/payoutReconciliation/claimIdempotency.test.ts
+++ b/test/integration/quickbooks/payoutReconciliation/claimIdempotency.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+
+import User from '@/app/api/core/models/User.model'
+import { SyncLogService } from '@/app/api/quickbooks/syncLog/syncLog.service'
+import { EntityType, EventType } from '@/app/api/core/types/log'
+
+import { seedHealthyPortal, TEST_PORTAL_ID } from '@test/helpers/seed'
+import { truncateAllTestTables } from '@test/helpers/testDb'
+
+describe('claimWebhookEvent — payout/settled idempotency', () => {
+  it('claims once and refuses the duplicate', async () => {
+    await truncateAllTestTables()
+    await seedHealthyPortal()
+
+    const user = { workspaceId: TEST_PORTAL_ID } as User
+    const service = new SyncLogService(user)
+
+    const first = await service.claimWebhookEvent({
+      copilotId: 'po_test_1',
+      entityType: EntityType.PAYOUT,
+      eventType: EventType.SETTLED,
+    })
+    const second = await service.claimWebhookEvent({
+      copilotId: 'po_test_1',
+      entityType: EntityType.PAYOUT,
+      eventType: EventType.SETTLED,
+    })
+
+    expect(first.claimed).toBe(true)
+    expect(second.claimed).toBe(false)
+  })
+})

--- a/test/integration/quickbooks/payoutReconciliation/duplicateLineItems.test.ts
+++ b/test/integration/quickbooks/payoutReconciliation/duplicateLineItems.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { eq } from 'drizzle-orm'
+
+import { db } from '@/db'
+import { QBSyncLog } from '@/db/schema/qbSyncLogs'
+import { EntityType, EventType, LogStatus } from '@/app/api/core/types/log'
+
+import { payoutPayload } from '@test/fixtures/payout.webhook'
+import {
+  seedHealthyPortal,
+  TEST_PORTAL_ID,
+  TEST_COPILOT_INVOICE_ID,
+  TEST_BANK_ACCOUNT_REF,
+  TEST_EXPENSE_ACCOUNT_REF,
+} from '@test/helpers/seed'
+import { setupPaymentSucceededTest } from '@test/helpers/paymentSucceededTestSetup'
+import { postWebhook } from '@test/helpers/webhook'
+
+describe('payout — two line items share the same invoice', () => {
+  const apis = setupPaymentSucceededTest()
+
+  it('aborts the deposit and logs a failed payout/settled entry', async () => {
+    // Seed the bank + expense account refs so the handler's missing-
+    // bankAccountRef guard can't be what trips instead of the guard under test.
+    await seedHealthyPortal({
+      portal: {
+        bankAccountRef: TEST_BANK_ACCOUNT_REF,
+        expenseAccountRef: TEST_EXPENSE_ACCOUNT_REF,
+      },
+      setting: { absorbedFeeFlag: true, bankDepositFeeFlag: true },
+    })
+    await db.insert(QBSyncLog).values({
+      portalId: TEST_PORTAL_ID,
+      copilotId: TEST_COPILOT_INVOICE_ID,
+      entityType: EntityType.INVOICE,
+      eventType: EventType.PAID,
+      status: LogStatus.SUCCESS,
+      quickbooksId: 'qbpay_A',
+    })
+
+    // Both line items reference the same invoice. gross (20000 + 375) - fee
+    // (375 + 50) = 19950, so netAmount is set to 19950 to keep the sum-mismatch
+    // guard from being what trips instead of the duplicate-line guard under test.
+    const payloadWithDuplicateInvoice = {
+      ...payoutPayload,
+      data: {
+        ...payoutPayload.data,
+        payout: { ...payoutPayload.data.payout, netAmount: 19950 },
+        lineItems: [
+          {
+            copilotInvoiceId: TEST_COPILOT_INVOICE_ID,
+            grossAmount: 20000,
+            feeAmount: 375,
+          },
+          {
+            copilotInvoiceId: TEST_COPILOT_INVOICE_ID,
+            grossAmount: 375,
+            feeAmount: 50,
+          },
+        ],
+      },
+    }
+
+    const res = await postWebhook(payloadWithDuplicateInvoice)
+    expect(res.status).toBe(200)
+
+    expect(apis.intuit.createDeposit).not.toHaveBeenCalled()
+
+    const logs = await db
+      .select()
+      .from(QBSyncLog)
+      .where(eq(QBSyncLog.copilotId, 'po_test_1'))
+    expect(logs).toHaveLength(1)
+    expect(logs[0]).toMatchObject({
+      portalId: TEST_PORTAL_ID,
+      entityType: EntityType.PAYOUT,
+      eventType: EventType.SETTLED,
+      status: LogStatus.FAILED,
+    })
+    // Pins the abort to the duplicate-line guard specifically — not the
+    // unresolved-line guard, the sum-mismatch guard, or the bankAccountRef guard.
+    expect(logs[0].errorMessage).toContain('duplicate invoice line items')
+  })
+})

--- a/test/integration/quickbooks/payoutReconciliation/duplicateLineItems.test.ts
+++ b/test/integration/quickbooks/payoutReconciliation/duplicateLineItems.test.ts
@@ -65,6 +65,8 @@ describe('payout — two line items share the same invoice', () => {
     expect(res.status).toBe(200)
 
     expect(apis.intuit.createDeposit).not.toHaveBeenCalled()
+    // Guard trips before any QBO round-trip, so account verification never runs.
+    expect(apis.intuit.getAnAccount).not.toHaveBeenCalled()
 
     const logs = await db
       .select()
@@ -76,6 +78,8 @@ describe('payout — two line items share the same invoice', () => {
       entityType: EntityType.PAYOUT,
       eventType: EventType.SETTLED,
       status: LogStatus.FAILED,
+      // Payout FAILED rows are terminal by design — never retryable.
+      shouldRetry: false,
     })
     // Pins the abort to the duplicate-line guard specifically — not the
     // unresolved-line guard, the sum-mismatch guard, or the bankAccountRef guard.

--- a/test/integration/quickbooks/payoutReconciliation/emptyLineItems.test.ts
+++ b/test/integration/quickbooks/payoutReconciliation/emptyLineItems.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { eq } from 'drizzle-orm'
+
+import { db } from '@/db'
+import { QBSyncLog } from '@/db/schema/qbSyncLogs'
+
+import { payoutPayload } from '@test/fixtures/payout.webhook'
+import {
+  seedHealthyPortal,
+  TEST_BANK_ACCOUNT_REF,
+  TEST_EXPENSE_ACCOUNT_REF,
+} from '@test/helpers/seed'
+import { setupPaymentSucceededTest } from '@test/helpers/paymentSucceededTestSetup'
+import { postWebhook } from '@test/helpers/webhook'
+
+describe('payout — no line items on the payload', () => {
+  const apis = setupPaymentSucceededTest()
+
+  it('returns 200 without creating a deposit or a payout/settled log', async () => {
+    await seedHealthyPortal({
+      portal: {
+        bankAccountRef: TEST_BANK_ACCOUNT_REF,
+        expenseAccountRef: TEST_EXPENSE_ACCOUNT_REF,
+      },
+      setting: { absorbedFeeFlag: true, bankDepositFeeFlag: true },
+    })
+
+    const payloadWithNoLineItems = {
+      ...payoutPayload,
+      data: { ...payoutPayload.data, lineItems: [] },
+    }
+
+    const res = await postWebhook(payloadWithNoLineItems)
+    expect(res.status).toBe(200)
+
+    expect(apis.intuit.createDeposit).not.toHaveBeenCalled()
+
+    // The schema's `.min(1)` on lineItems fails the safeParse before the
+    // handler ever calls claimWebhookEvent, so no row is written at all —
+    // not even a FAILED one.
+    const logs = await db
+      .select()
+      .from(QBSyncLog)
+      .where(eq(QBSyncLog.copilotId, 'po_test_1'))
+    expect(logs).toHaveLength(0)
+  })
+})

--- a/test/integration/quickbooks/payoutReconciliation/emptyLineItems.test.ts
+++ b/test/integration/quickbooks/payoutReconciliation/emptyLineItems.test.ts
@@ -34,6 +34,8 @@ describe('payout — no line items on the payload', () => {
     expect(res.status).toBe(200)
 
     expect(apis.intuit.createDeposit).not.toHaveBeenCalled()
+    // Parse fails before any QBO round-trip, so account verification never runs.
+    expect(apis.intuit.getAnAccount).not.toHaveBeenCalled()
 
     // The schema's `.min(1)` on lineItems fails the safeParse before the
     // handler ever calls claimWebhookEvent, so no row is written at all —

--- a/test/integration/quickbooks/payoutReconciliation/flagOff.test.ts
+++ b/test/integration/quickbooks/payoutReconciliation/flagOff.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { eq } from 'drizzle-orm'
+
+import { db } from '@/db'
+import { QBSyncLog } from '@/db/schema/qbSyncLogs'
+import { EntityType, EventType, LogStatus } from '@/app/api/core/types/log'
+
+import { payoutPayload } from '@test/fixtures/payout.webhook'
+import { seedHealthyPortal, TEST_COPILOT_INVOICE_ID } from '@test/helpers/seed'
+import { setupPaymentSucceededTest } from '@test/helpers/paymentSucceededTestSetup'
+import { postWebhook } from '@test/helpers/webhook'
+
+describe('payout — bank deposit fee flag is off', () => {
+  const apis = setupPaymentSucceededTest()
+
+  it('no-ops: no deposit is created and no payout/settled log is written', async () => {
+    const { portal } = await seedHealthyPortal({
+      setting: { absorbedFeeFlag: true, bankDepositFeeFlag: false },
+    })
+    await db.insert(QBSyncLog).values([
+      {
+        portalId: portal.portalId,
+        copilotId: TEST_COPILOT_INVOICE_ID,
+        entityType: EntityType.INVOICE,
+        eventType: EventType.PAID,
+        status: LogStatus.SUCCESS,
+        quickbooksId: 'qbpay_A',
+      },
+      {
+        portalId: portal.portalId,
+        copilotId: 'inv-cop-0002',
+        entityType: EntityType.INVOICE,
+        eventType: EventType.PAID,
+        status: LogStatus.SUCCESS,
+        quickbooksId: 'qbpay_B',
+      },
+    ])
+
+    const res = await postWebhook(payoutPayload)
+    expect(res.status).toBe(200)
+
+    expect(apis.intuit.createDeposit).not.toHaveBeenCalled()
+
+    const logs = await db
+      .select()
+      .from(QBSyncLog)
+      .where(eq(QBSyncLog.copilotId, 'po_test_1'))
+    expect(logs).toHaveLength(0)
+  })
+})

--- a/test/integration/quickbooks/payoutReconciliation/flagOff.test.ts
+++ b/test/integration/quickbooks/payoutReconciliation/flagOff.test.ts
@@ -40,6 +40,8 @@ describe('payout — bank deposit fee flag is off', () => {
     expect(res.status).toBe(200)
 
     expect(apis.intuit.createDeposit).not.toHaveBeenCalled()
+    // Flag-off no-op returns before any QBO round-trip.
+    expect(apis.intuit.getAnAccount).not.toHaveBeenCalled()
 
     const logs = await db
       .select()

--- a/test/integration/quickbooks/payoutReconciliation/happyPath.test.ts
+++ b/test/integration/quickbooks/payoutReconciliation/happyPath.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { eq } from 'drizzle-orm'
+
+import { db } from '@/db'
+import { QBSyncLog } from '@/db/schema/qbSyncLogs'
+import { EntityType, EventType, LogStatus } from '@/app/api/core/types/log'
+
+import { payoutPayload } from '@test/fixtures/payout.webhook'
+import {
+  seedHealthyPortal,
+  TEST_PORTAL_ID,
+  TEST_COPILOT_INVOICE_ID,
+  TEST_BANK_ACCOUNT_REF,
+  TEST_EXPENSE_ACCOUNT_REF,
+} from '@test/helpers/seed'
+import { setupPaymentSucceededTest } from '@test/helpers/paymentSucceededTestSetup'
+import { postWebhook } from '@test/helpers/webhook'
+
+describe('POST /api/quickbooks/webhook — payout.reconciliation_completed (batched deposit)', () => {
+  const apis = setupPaymentSucceededTest()
+
+  it('creates one deposit with N payment lines + fee line and logs PAYOUT/SETTLED success', async () => {
+    // Healthy, non-expired token (seed.ts default tokenSetTime/expiresIn) —
+    // isTokenFresh is true, so getValidQbTokens takes the extractTokens path,
+    // not the OAuth-refresh path. This is the common production case and
+    // guards the bankAccountRef regression in tokenRefresh.ts#extractTokens.
+    await seedHealthyPortal({
+      portal: {
+        bankAccountRef: TEST_BANK_ACCOUNT_REF,
+        expenseAccountRef: TEST_EXPENSE_ACCOUNT_REF,
+      },
+      setting: { absorbedFeeFlag: true, bankDepositFeeFlag: true },
+    })
+    await db.insert(QBSyncLog).values([
+      {
+        portalId: TEST_PORTAL_ID,
+        copilotId: TEST_COPILOT_INVOICE_ID,
+        entityType: EntityType.INVOICE,
+        eventType: EventType.PAID,
+        status: LogStatus.SUCCESS,
+        quickbooksId: 'qbpay_A',
+      },
+      {
+        portalId: TEST_PORTAL_ID,
+        copilotId: 'inv-cop-0002',
+        entityType: EntityType.INVOICE,
+        eventType: EventType.PAID,
+        status: LogStatus.SUCCESS,
+        quickbooksId: 'qbpay_B',
+      },
+    ])
+
+    const res = await postWebhook(payoutPayload)
+    expect(res.status).toBe(200)
+
+    expect(apis.intuit.createDeposit).toHaveBeenCalledTimes(1)
+    const [depositPayload] = apis.intuit.createDeposit.mock.calls[0]
+    expect(depositPayload.DepositToAccountRef).toEqual({
+      value: TEST_BANK_ACCOUNT_REF,
+    })
+    expect(depositPayload.TxnDate).toBe('2024-04-22')
+    expect(depositPayload.Line).toHaveLength(3) // 2 payments + 1 fee
+    expect(depositPayload.Line[0]).toMatchObject({
+      Amount: 200,
+      LinkedTxn: [{ TxnId: 'qbpay_A', TxnType: 'Payment', TxnLineId: '0' }],
+    })
+    expect(depositPayload.Line[1]).toMatchObject({
+      Amount: 150,
+      LinkedTxn: [{ TxnId: 'qbpay_B', TxnType: 'Payment', TxnLineId: '0' }],
+    })
+    expect(depositPayload.Line[2]).toMatchObject({
+      Amount: -5.75,
+      DepositLineDetail: { AccountRef: { value: TEST_EXPENSE_ACCOUNT_REF } },
+    })
+
+    const logs = await db
+      .select()
+      .from(QBSyncLog)
+      .where(eq(QBSyncLog.copilotId, 'po_test_1'))
+    expect(logs).toHaveLength(1)
+    expect(logs[0]).toMatchObject({
+      portalId: TEST_PORTAL_ID,
+      entityType: EntityType.PAYOUT,
+      eventType: EventType.SETTLED,
+      status: LogStatus.SUCCESS,
+      quickbooksId: expect.any(String),
+    })
+  })
+})

--- a/test/integration/quickbooks/payoutReconciliation/happyPath.test.ts
+++ b/test/integration/quickbooks/payoutReconciliation/happyPath.test.ts
@@ -83,7 +83,8 @@ describe('POST /api/quickbooks/webhook — payout.reconciliation_completed (batc
       entityType: EntityType.PAYOUT,
       eventType: EventType.SETTLED,
       status: LogStatus.SUCCESS,
-      quickbooksId: expect.any(String),
+      // Deterministic: createBankDepositForPayment returns res.Deposit.Id.
+      quickbooksId: 'qb-deposit-1',
     })
   })
 })

--- a/test/integration/quickbooks/payoutReconciliation/idempotentRedelivery.test.ts
+++ b/test/integration/quickbooks/payoutReconciliation/idempotentRedelivery.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { eq } from 'drizzle-orm'
+
+import { db } from '@/db'
+import { QBSyncLog } from '@/db/schema/qbSyncLogs'
+import { EntityType, EventType, LogStatus } from '@/app/api/core/types/log'
+
+import { payoutPayload } from '@test/fixtures/payout.webhook'
+import {
+  seedHealthyPortal,
+  TEST_PORTAL_ID,
+  TEST_COPILOT_INVOICE_ID,
+  TEST_BANK_ACCOUNT_REF,
+  TEST_EXPENSE_ACCOUNT_REF,
+} from '@test/helpers/seed'
+import { setupPaymentSucceededTest } from '@test/helpers/paymentSucceededTestSetup'
+import { postWebhook } from '@test/helpers/webhook'
+
+describe('payout — the same webhook is redelivered', () => {
+  const apis = setupPaymentSucceededTest()
+
+  it('creates the deposit only once and keeps a single payout/settled log', async () => {
+    await seedHealthyPortal({
+      portal: {
+        bankAccountRef: TEST_BANK_ACCOUNT_REF,
+        expenseAccountRef: TEST_EXPENSE_ACCOUNT_REF,
+      },
+      setting: { absorbedFeeFlag: true, bankDepositFeeFlag: true },
+    })
+    await db.insert(QBSyncLog).values([
+      {
+        portalId: TEST_PORTAL_ID,
+        copilotId: TEST_COPILOT_INVOICE_ID,
+        entityType: EntityType.INVOICE,
+        eventType: EventType.PAID,
+        status: LogStatus.SUCCESS,
+        quickbooksId: 'qbpay_A',
+      },
+      {
+        portalId: TEST_PORTAL_ID,
+        copilotId: 'inv-cop-0002',
+        entityType: EntityType.INVOICE,
+        eventType: EventType.PAID,
+        status: LogStatus.SUCCESS,
+        quickbooksId: 'qbpay_B',
+      },
+    ])
+
+    const first = await postWebhook(payoutPayload)
+    expect(first.status).toBe(200)
+    const second = await postWebhook(payoutPayload)
+    expect(second.status).toBe(200)
+
+    expect(apis.intuit.createDeposit).toHaveBeenCalledTimes(1)
+
+    const logs = await db
+      .select()
+      .from(QBSyncLog)
+      .where(eq(QBSyncLog.copilotId, 'po_test_1'))
+    expect(logs).toHaveLength(1)
+    expect(logs[0]).toMatchObject({
+      portalId: TEST_PORTAL_ID,
+      entityType: EntityType.PAYOUT,
+      eventType: EventType.SETTLED,
+      status: LogStatus.SUCCESS,
+    })
+  })
+})

--- a/test/integration/quickbooks/payoutReconciliation/negativeFee.test.ts
+++ b/test/integration/quickbooks/payoutReconciliation/negativeFee.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import { eq } from 'drizzle-orm'
+
+import { db } from '@/db'
+import { QBSyncLog } from '@/db/schema/qbSyncLogs'
+import { EntityType, EventType, LogStatus } from '@/app/api/core/types/log'
+
+import { payoutPayload } from '@test/fixtures/payout.webhook'
+import {
+  seedHealthyPortal,
+  TEST_PORTAL_ID,
+  TEST_COPILOT_INVOICE_ID,
+  TEST_BANK_ACCOUNT_REF,
+  TEST_EXPENSE_ACCOUNT_REF,
+} from '@test/helpers/seed'
+import { setupPaymentSucceededTest } from '@test/helpers/paymentSucceededTestSetup'
+import { postWebhook } from '@test/helpers/webhook'
+
+describe('payout — the total fee across line items is negative', () => {
+  const apis = setupPaymentSucceededTest()
+
+  it('aborts the deposit and logs a failed payout/settled entry', async () => {
+    // Seed the bank + expense account refs so the missing-bankAccountRef guard
+    // can't be what trips instead of the guard under test.
+    await seedHealthyPortal({
+      portal: {
+        bankAccountRef: TEST_BANK_ACCOUNT_REF,
+        expenseAccountRef: TEST_EXPENSE_ACCOUNT_REF,
+      },
+      setting: { absorbedFeeFlag: true, bankDepositFeeFlag: true },
+    })
+    // Both invoices resolve, so the unresolved-line guard can't trip either.
+    await db.insert(QBSyncLog).values([
+      {
+        portalId: TEST_PORTAL_ID,
+        copilotId: TEST_COPILOT_INVOICE_ID,
+        entityType: EntityType.INVOICE,
+        eventType: EventType.PAID,
+        status: LogStatus.SUCCESS,
+        quickbooksId: 'qbpay_A',
+      },
+      {
+        portalId: TEST_PORTAL_ID,
+        copilotId: 'inv-cop-0002',
+        entityType: EntityType.INVOICE,
+        eventType: EventType.PAID,
+        status: LogStatus.SUCCESS,
+        quickbooksId: 'qbpay_B',
+      },
+    ])
+
+    // Positive gross on every line (so the refund guard passes), but the
+    // aggregate fee is negative: 375 + (-1000) = -625. netAmount is set to the
+    // internally consistent gross - fee (35000 - (-625) = 35625) so it is the
+    // negative-fee guard — not a sum mismatch — that aborts.
+    const payloadWithNegativeFee = {
+      ...payoutPayload,
+      data: {
+        ...payoutPayload.data,
+        payout: { ...payoutPayload.data.payout, netAmount: 35625 },
+        lineItems: [
+          {
+            copilotInvoiceId: TEST_COPILOT_INVOICE_ID,
+            grossAmount: 20000,
+            feeAmount: 375,
+          },
+          {
+            copilotInvoiceId: 'inv-cop-0002',
+            grossAmount: 15000,
+            feeAmount: -1000,
+          },
+        ],
+      },
+    }
+
+    const res = await postWebhook(payloadWithNegativeFee)
+    expect(res.status).toBe(200)
+
+    expect(apis.intuit.createDeposit).not.toHaveBeenCalled()
+
+    const logs = await db
+      .select()
+      .from(QBSyncLog)
+      .where(eq(QBSyncLog.copilotId, 'po_test_1'))
+    expect(logs).toHaveLength(1)
+    expect(logs[0]).toMatchObject({
+      portalId: TEST_PORTAL_ID,
+      entityType: EntityType.PAYOUT,
+      eventType: EventType.SETTLED,
+      status: LogStatus.FAILED,
+    })
+    // Pins the abort to the negative-fee guard specifically — not the refund,
+    // unresolved-line, sum-mismatch, or bankAccountRef guards.
+    expect(logs[0].errorMessage).toContain('negative aggregate fee (-625)')
+  })
+})

--- a/test/integration/quickbooks/payoutReconciliation/negativeFee.test.ts
+++ b/test/integration/quickbooks/payoutReconciliation/negativeFee.test.ts
@@ -77,6 +77,8 @@ describe('payout — the total fee across line items is negative', () => {
     expect(res.status).toBe(200)
 
     expect(apis.intuit.createDeposit).not.toHaveBeenCalled()
+    // Guard trips before any QBO round-trip, so account verification never runs.
+    expect(apis.intuit.getAnAccount).not.toHaveBeenCalled()
 
     const logs = await db
       .select()
@@ -88,6 +90,8 @@ describe('payout — the total fee across line items is negative', () => {
       entityType: EntityType.PAYOUT,
       eventType: EventType.SETTLED,
       status: LogStatus.FAILED,
+      // Payout FAILED rows are terminal by design — never retryable.
+      shouldRetry: false,
     })
     // Pins the abort to the negative-fee guard specifically — not the refund,
     // unresolved-line, sum-mismatch, or bankAccountRef guards.

--- a/test/integration/quickbooks/payoutReconciliation/refundPresent.test.ts
+++ b/test/integration/quickbooks/payoutReconciliation/refundPresent.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { eq } from 'drizzle-orm'
+
+import { db } from '@/db'
+import { QBSyncLog } from '@/db/schema/qbSyncLogs'
+import { EntityType, EventType, LogStatus } from '@/app/api/core/types/log'
+
+import { payoutPayload } from '@test/fixtures/payout.webhook'
+import {
+  seedHealthyPortal,
+  TEST_PORTAL_ID,
+  TEST_COPILOT_INVOICE_ID,
+  TEST_BANK_ACCOUNT_REF,
+  TEST_EXPENSE_ACCOUNT_REF,
+} from '@test/helpers/seed'
+import { setupPaymentSucceededTest } from '@test/helpers/paymentSucceededTestSetup'
+import { postWebhook } from '@test/helpers/webhook'
+
+describe('payout — a line item is a refund (negative gross amount)', () => {
+  const apis = setupPaymentSucceededTest()
+
+  it('aborts the deposit and logs a failed payout/settled entry', async () => {
+    // Seed the bank + expense account refs so the handler's missing-
+    // bankAccountRef guard can't be what trips instead of the guard under test.
+    await seedHealthyPortal({
+      portal: {
+        bankAccountRef: TEST_BANK_ACCOUNT_REF,
+        expenseAccountRef: TEST_EXPENSE_ACCOUNT_REF,
+      },
+      setting: { absorbedFeeFlag: true, bankDepositFeeFlag: true },
+    })
+    // PAID sync logs for all three lines — including the refund line's
+    // invoice — so every invoice resolves and the unresolved-line guard
+    // can't be what trips instead of the refund guard.
+    await db.insert(QBSyncLog).values([
+      {
+        portalId: TEST_PORTAL_ID,
+        copilotId: TEST_COPILOT_INVOICE_ID,
+        entityType: EntityType.INVOICE,
+        eventType: EventType.PAID,
+        status: LogStatus.SUCCESS,
+        quickbooksId: 'qbpay_A',
+      },
+      {
+        portalId: TEST_PORTAL_ID,
+        copilotId: 'inv-cop-0002',
+        entityType: EntityType.INVOICE,
+        eventType: EventType.PAID,
+        status: LogStatus.SUCCESS,
+        quickbooksId: 'qbpay_B',
+      },
+      {
+        portalId: TEST_PORTAL_ID,
+        copilotId: 'inv-cop-0003',
+        entityType: EntityType.INVOICE,
+        eventType: EventType.PAID,
+        status: LogStatus.SUCCESS,
+        quickbooksId: 'qbpay_C',
+      },
+    ])
+
+    const payloadWithRefund = {
+      ...payoutPayload,
+      data: {
+        ...payoutPayload.data,
+        payout: { ...payoutPayload.data.payout, netAmount: 29425 },
+        lineItems: [
+          ...payoutPayload.data.lineItems,
+          {
+            copilotInvoiceId: 'inv-cop-0003',
+            grossAmount: -5000,
+            feeAmount: 0,
+          },
+        ],
+      },
+    }
+
+    const res = await postWebhook(payloadWithRefund)
+    expect(res.status).toBe(200)
+
+    expect(apis.intuit.createDeposit).not.toHaveBeenCalled()
+
+    const logs = await db
+      .select()
+      .from(QBSyncLog)
+      .where(eq(QBSyncLog.copilotId, 'po_test_1'))
+    expect(logs).toHaveLength(1)
+    expect(logs[0]).toMatchObject({
+      portalId: TEST_PORTAL_ID,
+      entityType: EntityType.PAYOUT,
+      eventType: EventType.SETTLED,
+      status: LogStatus.FAILED,
+    })
+    // Pins the abort to the refund guard specifically — not the
+    // unresolved-line guard, the sum-mismatch guard, or the bankAccountRef guard.
+    expect(logs[0].errorMessage).toContain('contains refund lines')
+  })
+})

--- a/test/integration/quickbooks/payoutReconciliation/refundPresent.test.ts
+++ b/test/integration/quickbooks/payoutReconciliation/refundPresent.test.ts
@@ -79,6 +79,8 @@ describe('payout — a line item is a refund (negative gross amount)', () => {
     expect(res.status).toBe(200)
 
     expect(apis.intuit.createDeposit).not.toHaveBeenCalled()
+    // Guard trips before any QBO round-trip, so account verification never runs.
+    expect(apis.intuit.getAnAccount).not.toHaveBeenCalled()
 
     const logs = await db
       .select()
@@ -90,6 +92,8 @@ describe('payout — a line item is a refund (negative gross amount)', () => {
       entityType: EntityType.PAYOUT,
       eventType: EventType.SETTLED,
       status: LogStatus.FAILED,
+      // Payout FAILED rows are terminal by design — never retryable.
+      shouldRetry: false,
     })
     // Pins the abort to the refund guard specifically — not the
     // unresolved-line guard, the sum-mismatch guard, or the bankAccountRef guard.

--- a/test/integration/quickbooks/payoutReconciliation/resolvePayments.test.ts
+++ b/test/integration/quickbooks/payoutReconciliation/resolvePayments.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+
+import { db } from '@/db'
+import { QBSyncLog } from '@/db/schema/qbSyncLogs'
+import User from '@/app/api/core/models/User.model'
+import { SyncLogService } from '@/app/api/quickbooks/syncLog/syncLog.service'
+import { EntityType, EventType, LogStatus } from '@/app/api/core/types/log'
+
+import { seedHealthyPortal, TEST_PORTAL_ID } from '@test/helpers/seed'
+import { truncateAllTestTables } from '@test/helpers/testDb'
+
+describe('SyncLogService.getSuccessfulPaidPaymentIds', () => {
+  it('returns only SUCCESS INVOICE/PAID rows for this portal', async () => {
+    await truncateAllTestTables()
+    await seedHealthyPortal()
+
+    await db.insert(QBSyncLog).values([
+      {
+        portalId: TEST_PORTAL_ID,
+        copilotId: 'inv_a',
+        entityType: EntityType.INVOICE,
+        eventType: EventType.PAID,
+        status: LogStatus.SUCCESS,
+        quickbooksId: 'qbpay_a',
+      },
+      {
+        portalId: TEST_PORTAL_ID,
+        copilotId: 'inv_b',
+        entityType: EntityType.INVOICE,
+        eventType: EventType.PAID,
+        status: LogStatus.FAILED,
+        quickbooksId: 'qbpay_b',
+      },
+      {
+        portalId: 'other-portal',
+        copilotId: 'inv_c',
+        entityType: EntityType.INVOICE,
+        eventType: EventType.PAID,
+        status: LogStatus.SUCCESS,
+        quickbooksId: 'qbpay_c',
+      },
+    ])
+
+    const user = { workspaceId: TEST_PORTAL_ID } as User
+    const service = new SyncLogService(user)
+
+    const result = await service.getSuccessfulPaidPaymentIds([
+      'inv_a',
+      'inv_b',
+      'inv_c',
+    ])
+
+    expect(result.get('inv_a')).toBe('qbpay_a')
+    expect(result.has('inv_b')).toBe(false) // FAILED excluded
+    expect(result.has('inv_c')).toBe(false) // other portal excluded
+    expect(result.size).toBe(1)
+  })
+})

--- a/test/integration/quickbooks/payoutReconciliation/sumMismatch.test.ts
+++ b/test/integration/quickbooks/payoutReconciliation/sumMismatch.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { eq } from 'drizzle-orm'
+
+import { db } from '@/db'
+import { QBSyncLog } from '@/db/schema/qbSyncLogs'
+import { EntityType, EventType, LogStatus } from '@/app/api/core/types/log'
+
+import { payoutPayload } from '@test/fixtures/payout.webhook'
+import {
+  seedHealthyPortal,
+  TEST_PORTAL_ID,
+  TEST_COPILOT_INVOICE_ID,
+  TEST_BANK_ACCOUNT_REF,
+  TEST_EXPENSE_ACCOUNT_REF,
+} from '@test/helpers/seed'
+import { setupPaymentSucceededTest } from '@test/helpers/paymentSucceededTestSetup'
+import { postWebhook } from '@test/helpers/webhook'
+
+describe('payout — reported net amount does not match the line items', () => {
+  const apis = setupPaymentSucceededTest()
+
+  it('aborts the deposit and logs a failed payout/settled entry', async () => {
+    // Seed the bank + expense account refs so the handler's missing-
+    // bankAccountRef guard can't be what trips instead of the guard under test.
+    await seedHealthyPortal({
+      portal: {
+        bankAccountRef: TEST_BANK_ACCOUNT_REF,
+        expenseAccountRef: TEST_EXPENSE_ACCOUNT_REF,
+      },
+      setting: { absorbedFeeFlag: true, bankDepositFeeFlag: true },
+    })
+    await db.insert(QBSyncLog).values([
+      {
+        portalId: TEST_PORTAL_ID,
+        copilotId: TEST_COPILOT_INVOICE_ID,
+        entityType: EntityType.INVOICE,
+        eventType: EventType.PAID,
+        status: LogStatus.SUCCESS,
+        quickbooksId: 'qbpay_A',
+      },
+      {
+        portalId: TEST_PORTAL_ID,
+        copilotId: 'inv-cop-0002',
+        entityType: EntityType.INVOICE,
+        eventType: EventType.PAID,
+        status: LogStatus.SUCCESS,
+        quickbooksId: 'qbpay_B',
+      },
+    ])
+
+    const payloadWithWrongNetAmount = {
+      ...payoutPayload,
+      data: {
+        ...payoutPayload.data,
+        payout: { ...payoutPayload.data.payout, netAmount: 99999 },
+      },
+    }
+
+    const res = await postWebhook(payloadWithWrongNetAmount)
+    expect(res.status).toBe(200)
+
+    expect(apis.intuit.createDeposit).not.toHaveBeenCalled()
+
+    const logs = await db
+      .select()
+      .from(QBSyncLog)
+      .where(eq(QBSyncLog.copilotId, 'po_test_1'))
+    expect(logs).toHaveLength(1)
+    expect(logs[0]).toMatchObject({
+      portalId: TEST_PORTAL_ID,
+      entityType: EntityType.PAYOUT,
+      eventType: EventType.SETTLED,
+      status: LogStatus.FAILED,
+    })
+    // Pins the abort to the sum-mismatch guard specifically — not the
+    // unresolved-line guard, the refund guard, or the bankAccountRef guard.
+    expect(logs[0].errorMessage).toContain(
+      'deposit total 34425 != payout net 99999',
+    )
+  })
+})

--- a/test/integration/quickbooks/payoutReconciliation/sumMismatch.test.ts
+++ b/test/integration/quickbooks/payoutReconciliation/sumMismatch.test.ts
@@ -60,6 +60,8 @@ describe('payout — reported net amount does not match the line items', () => {
     expect(res.status).toBe(200)
 
     expect(apis.intuit.createDeposit).not.toHaveBeenCalled()
+    // Guard trips before any QBO round-trip, so account verification never runs.
+    expect(apis.intuit.getAnAccount).not.toHaveBeenCalled()
 
     const logs = await db
       .select()
@@ -71,6 +73,8 @@ describe('payout — reported net amount does not match the line items', () => {
       entityType: EntityType.PAYOUT,
       eventType: EventType.SETTLED,
       status: LogStatus.FAILED,
+      // Payout FAILED rows are terminal by design — never retryable.
+      shouldRetry: false,
     })
     // Pins the abort to the sum-mismatch guard specifically — not the
     // unresolved-line guard, the refund guard, or the bankAccountRef guard.

--- a/test/integration/quickbooks/payoutReconciliation/unresolvedLine.test.ts
+++ b/test/integration/quickbooks/payoutReconciliation/unresolvedLine.test.ts
@@ -46,6 +46,8 @@ describe('payout — one invoice has no PAID sync log', () => {
     expect(res.status).toBe(200)
 
     expect(apis.intuit.createDeposit).not.toHaveBeenCalled()
+    // Guard trips before any QBO round-trip, so account verification never runs.
+    expect(apis.intuit.getAnAccount).not.toHaveBeenCalled()
 
     const logs = await db
       .select()
@@ -57,6 +59,8 @@ describe('payout — one invoice has no PAID sync log', () => {
       entityType: EntityType.PAYOUT,
       eventType: EventType.SETTLED,
       status: LogStatus.FAILED,
+      // Payout FAILED rows are terminal by design — never retryable.
+      shouldRetry: false,
     })
     // Pins the abort to the unresolved-line guard specifically — not the
     // refund guard, the sum-mismatch guard, or the bankAccountRef guard.

--- a/test/integration/quickbooks/payoutReconciliation/unresolvedLine.test.ts
+++ b/test/integration/quickbooks/payoutReconciliation/unresolvedLine.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { eq } from 'drizzle-orm'
+
+import { db } from '@/db'
+import { QBSyncLog } from '@/db/schema/qbSyncLogs'
+import { EntityType, EventType, LogStatus } from '@/app/api/core/types/log'
+
+import { payoutPayload } from '@test/fixtures/payout.webhook'
+import {
+  seedHealthyPortal,
+  TEST_PORTAL_ID,
+  TEST_COPILOT_INVOICE_ID,
+  TEST_BANK_ACCOUNT_REF,
+  TEST_EXPENSE_ACCOUNT_REF,
+} from '@test/helpers/seed'
+import { setupPaymentSucceededTest } from '@test/helpers/paymentSucceededTestSetup'
+import { postWebhook } from '@test/helpers/webhook'
+
+describe('payout — one invoice has no PAID sync log', () => {
+  const apis = setupPaymentSucceededTest()
+
+  it('aborts the deposit and logs a failed payout/settled entry', async () => {
+    // Seed the bank + expense account refs so the handler's missing-
+    // bankAccountRef guard can't be what trips instead of the guard under test.
+    await seedHealthyPortal({
+      portal: {
+        bankAccountRef: TEST_BANK_ACCOUNT_REF,
+        expenseAccountRef: TEST_EXPENSE_ACCOUNT_REF,
+      },
+      setting: { absorbedFeeFlag: true, bankDepositFeeFlag: true },
+    })
+    // Only the first invoice has a PAID sync log; inv-cop-0002 is missing one,
+    // so the handler can't resolve it to a QBO payment id.
+    await db.insert(QBSyncLog).values([
+      {
+        portalId: TEST_PORTAL_ID,
+        copilotId: TEST_COPILOT_INVOICE_ID,
+        entityType: EntityType.INVOICE,
+        eventType: EventType.PAID,
+        status: LogStatus.SUCCESS,
+        quickbooksId: 'qbpay_A',
+      },
+    ])
+
+    const res = await postWebhook(payoutPayload)
+    expect(res.status).toBe(200)
+
+    expect(apis.intuit.createDeposit).not.toHaveBeenCalled()
+
+    const logs = await db
+      .select()
+      .from(QBSyncLog)
+      .where(eq(QBSyncLog.copilotId, 'po_test_1'))
+    expect(logs).toHaveLength(1)
+    expect(logs[0]).toMatchObject({
+      portalId: TEST_PORTAL_ID,
+      entityType: EntityType.PAYOUT,
+      eventType: EventType.SETTLED,
+      status: LogStatus.FAILED,
+    })
+    // Pins the abort to the unresolved-line guard specifically — not the
+    // refund guard, the sum-mismatch guard, or the bankAccountRef guard.
+    expect(logs[0].errorMessage).toContain(
+      'no SUCCESS INVOICE/PAID sync log for invoices [inv-cop-0002]',
+    )
+  })
+})

--- a/test/integration/quickbooks/setting/bankAccounts.test.ts
+++ b/test/integration/quickbooks/setting/bankAccounts.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { testApiHandler } from 'next-test-api-route-handler'
+
+import * as appHandler from '@/app/api/quickbooks/setting/bank-account/route'
+import { truncateAllTestTables } from '@test/helpers/testDb'
+import { createMockIntuitAPI, installMockApis } from '@test/helpers/mocks'
+import { seedHealthyPortal, TEST_WEBHOOK_TOKEN } from '@test/helpers/seed'
+
+describe('GET /api/quickbooks/setting/bank-account', () => {
+  beforeEach(async () => {
+    await truncateAllTestTables()
+    installMockApis({
+      intuit: createMockIntuitAPI({
+        // Mirrors QBO's real response shape: the controller's SELECT lists
+        // QB_ACCOUNT_COLUMNS (Id, Name, SyncToken, Active, AccountType), and
+        // QBO only returns the columns asked for.
+        customQuery: vi.fn().mockResolvedValue({
+          Account: [
+            {
+              Id: '103',
+              Name: 'Checking',
+              SyncToken: '0',
+              Active: true,
+              AccountType: 'Bank',
+            },
+          ],
+        }),
+      }),
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns active bank accounts with Id and Name present', async () => {
+    await seedHealthyPortal()
+
+    await testApiHandler({
+      appHandler,
+      url: `/api/quickbooks/setting/bank-account?token=${TEST_WEBHOOK_TOKEN}`,
+      test: async ({ fetch }) => {
+        const res = await fetch({ method: 'GET' })
+        expect(res.status).toBe(200)
+        const body = await res.json()
+        expect(body.accounts).toHaveLength(1)
+        // Full row also carries SyncToken/Active/AccountType (see mock above);
+        // the UI only needs Id/Name, so check those two are present.
+        expect(body.accounts[0]).toMatchObject({
+          Id: '103',
+          Name: 'Checking',
+        })
+      },
+    })
+  })
+
+  it('returns 401 without a token', async () => {
+    await testApiHandler({
+      appHandler,
+      url: `/api/quickbooks/setting/bank-account`,
+      test: async ({ fetch }) => {
+        const res = await fetch({ method: 'GET' })
+        expect(res.status).toBe(401)
+      },
+    })
+  })
+})

--- a/test/integration/quickbooks/setting/invoiceSettings.test.ts
+++ b/test/integration/quickbooks/setting/invoiceSettings.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { testApiHandler } from 'next-test-api-route-handler'
+import { eq } from 'drizzle-orm'
+
+import * as appHandler from '@/app/api/quickbooks/setting/route'
+import { db } from '@/db'
+import { QBSetting } from '@/db/schema/qbSettings'
+import { QBPortalConnection } from '@/db/schema/qbPortalConnections'
+import { truncateAllTestTables } from '@test/helpers/testDb'
+import { installMockApis } from '@test/helpers/mocks'
+import {
+  seedHealthyPortal,
+  TEST_PORTAL_ID,
+  TEST_WEBHOOK_TOKEN,
+} from '@test/helpers/seed'
+
+describe('GET/POST /api/quickbooks/setting?type=invoice', () => {
+  beforeEach(async () => {
+    await truncateAllTestTables()
+    installMockApis()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('persists bankDepositFeeFlag on qb_settings and bankAccountRef on qb_portal_connections', async () => {
+    await seedHealthyPortal()
+
+    await testApiHandler({
+      appHandler,
+      url: `/api/quickbooks/setting?type=invoice&token=${TEST_WEBHOOK_TOKEN}`,
+      test: async ({ fetch }) => {
+        const res = await fetch({
+          method: 'POST',
+          body: JSON.stringify({
+            type: 'invoice',
+            absorbedFeeFlag: false,
+            useCompanyNameFlag: false,
+            bankDepositFeeFlag: true,
+            bankAccountRef: '103',
+          }),
+          headers: { 'content-type': 'application/json' },
+        })
+        expect(res.status).toBe(201)
+      },
+    })
+
+    const [setting] = await db
+      .select()
+      .from(QBSetting)
+      .where(eq(QBSetting.portalId, TEST_PORTAL_ID))
+    expect(setting.bankDepositFeeFlag).toBe(true)
+
+    const [portalConnection] = await db
+      .select()
+      .from(QBPortalConnection)
+      .where(eq(QBPortalConnection.portalId, TEST_PORTAL_ID))
+    expect(portalConnection.bankAccountRef).toBe('103')
+  })
+
+  it('rejects bankDepositFeeFlag true without a bankAccountRef with 422', async () => {
+    await seedHealthyPortal()
+
+    await testApiHandler({
+      appHandler,
+      url: `/api/quickbooks/setting?type=invoice&token=${TEST_WEBHOOK_TOKEN}`,
+      test: async ({ fetch }) => {
+        const res = await fetch({
+          method: 'POST',
+          body: JSON.stringify({
+            type: 'invoice',
+            absorbedFeeFlag: false,
+            useCompanyNameFlag: false,
+            bankDepositFeeFlag: true,
+          }),
+          headers: { 'content-type': 'application/json' },
+        })
+        expect(res.status).toBe(422)
+      },
+    })
+
+    // Rejected request must not have written a bank account ref.
+    const [portalConnection] = await db
+      .select()
+      .from(QBPortalConnection)
+      .where(eq(QBPortalConnection.portalId, TEST_PORTAL_ID))
+    expect(portalConnection.bankAccountRef).toBeNull()
+  })
+
+  it('returns bankAccountRef alongside the invoice setting', async () => {
+    await seedHealthyPortal({
+      portal: { bankAccountRef: '103' },
+    })
+
+    await testApiHandler({
+      appHandler,
+      url: `/api/quickbooks/setting?type=invoice&token=${TEST_WEBHOOK_TOKEN}`,
+      test: async ({ fetch }) => {
+        const res = await fetch({ method: 'GET' })
+        expect(res.status).toBe(200)
+        const body = await res.json()
+        expect(body.bankAccountRef).toBe('103')
+        expect(body.setting).toMatchObject({
+          absorbedFeeFlag: false,
+          useCompanyNameFlag: false,
+        })
+      },
+    })
+  })
+})

--- a/test/integration/quickbooks/syncLog/staleReaperPayoutTerminal.test.ts
+++ b/test/integration/quickbooks/syncLog/staleReaperPayoutTerminal.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import { eq } from 'drizzle-orm'
+import dayjs from 'dayjs'
+
+import { db } from '@/db'
+import { QBSyncLog } from '@/db/schema/qbSyncLogs'
+import {
+  SyncLogService,
+  STALE_PENDING_THRESHOLD_MINUTES,
+} from '@/app/api/quickbooks/syncLog/syncLog.service'
+import { EntityType, EventType, LogStatus } from '@/app/api/core/types/log'
+
+import { seedHealthyPortal, TEST_PORTAL_ID } from '@test/helpers/seed'
+import { truncateAllTestTables } from '@test/helpers/testDb'
+
+const makeUser = () => ({ workspaceId: TEST_PORTAL_ID }) as any
+
+describe('flipStalePendingToFailed keeps a reaped payout claim terminal', () => {
+  beforeEach(async () => {
+    await truncateAllTestTables()
+    await seedHealthyPortal()
+  })
+
+  it('flips both stale PENDING rows to FAILED, but only the payout row is non-retryable', async () => {
+    const staleCreatedAt = dayjs()
+      .subtract(STALE_PENDING_THRESHOLD_MINUTES + 5, 'minutes')
+      .toDate()
+
+    await db.insert(QBSyncLog).values([
+      {
+        portalId: TEST_PORTAL_ID,
+        copilotId: 'po_stale_1',
+        entityType: EntityType.PAYOUT,
+        eventType: EventType.SETTLED,
+        status: LogStatus.PENDING,
+        createdAt: staleCreatedAt,
+      },
+      {
+        portalId: TEST_PORTAL_ID,
+        copilotId: 'inv_stale_1',
+        entityType: EntityType.INVOICE,
+        eventType: EventType.PAID,
+        status: LogStatus.PENDING,
+        createdAt: staleCreatedAt,
+      },
+    ])
+
+    const service = new SyncLogService(makeUser())
+    await service.flipStalePendingToFailed()
+
+    const [payoutLog] = await db
+      .select()
+      .from(QBSyncLog)
+      .where(eq(QBSyncLog.copilotId, 'po_stale_1'))
+    const [invoiceLog] = await db
+      .select()
+      .from(QBSyncLog)
+      .where(eq(QBSyncLog.copilotId, 'inv_stale_1'))
+
+    expect(payoutLog.status).toBe(LogStatus.FAILED)
+    expect(payoutLog.shouldRetry).toBe(false)
+
+    expect(invoiceLog.status).toBe(LogStatus.FAILED)
+    expect(invoiceLog.shouldRetry).toBe(true)
+  })
+})

--- a/test/integration/setup.ts
+++ b/test/integration/setup.ts
@@ -37,6 +37,10 @@ vi.mock('@/utils/intuitAPI', () => ({
   // Named export used by src/utils/error.ts to detect Intuit-sourced APIErrors
   // when unwrapping error messages in the webhook catch block.
   IntuitAPIErrorMessage: '#IntuitAPIErrorMessage#',
+  // Named export consumed directly by controllers (e.g. bank-account) to
+  // build a customQuery SELECT list. Must be kept in sync with the real
+  // `QB_ACCOUNT_COLUMNS` in src/utils/intuitAPI.ts.
+  QB_ACCOUNT_COLUMNS: ['Id', 'Name', 'SyncToken', 'Active', 'AccountType'],
 }))
 
 // `@/utils/intuit` is the OAuth wrapper (separate from `@/utils/intuitAPI`,

--- a/test/unit/type/settingRequestSchema.test.ts
+++ b/test/unit/type/settingRequestSchema.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { SettingRequestSchema, SettingType } from '@/type/common'
+
+describe('SettingRequestSchema — invoice bank deposit validation', () => {
+  const base = {
+    type: SettingType.INVOICE,
+    absorbedFeeFlag: false,
+    useCompanyNameFlag: false,
+  }
+
+  it('accepts bank deposit off without a bank account', () => {
+    const r = SettingRequestSchema.safeParse({
+      ...base,
+      bankDepositFeeFlag: false,
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it('rejects bank deposit on without a bank account', () => {
+    const r = SettingRequestSchema.safeParse({
+      ...base,
+      bankDepositFeeFlag: true,
+    })
+    expect(r.success).toBe(false)
+    if (!r.success) {
+      expect(
+        r.error.issues.some((i) => i.path.includes('bankAccountRef')),
+      ).toBe(true)
+    }
+  })
+
+  it('accepts bank deposit on with a bank account', () => {
+    const r = SettingRequestSchema.safeParse({
+      ...base,
+      bankDepositFeeFlag: true,
+      bankAccountRef: '123',
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it('rejects invoice missing bankDepositFeeFlag', () => {
+    const r = SettingRequestSchema.safeParse({ ...base })
+    expect(r.success).toBe(false)
+  })
+})

--- a/test/unit/utils/tokenRefresh.test.ts
+++ b/test/unit/utils/tokenRefresh.test.ts
@@ -119,6 +119,7 @@ const basePortalRow = {
   assetAccountRef: 'asset-ref',
   serviceItemRef: 'service-ref',
   clientFeeRef: 'client-fee-ref',
+  bankAccountRef: 'bank-acc-ref-123',
   isSuspended: false,
   createdAt: new Date(),
   updatedAt: new Date(),
@@ -162,6 +163,10 @@ describe('getValidQbTokens', () => {
     const tokens = await getValidQbTokens('portal-abc')
 
     expect(tokens.accessToken).toBe('stored-access')
+    // Regression guard: extractTokens() (the fresh-token path) once omitted
+    // bankAccountRef entirely, so the payout batched-deposit handler threw
+    // "Bank account ref is not configured" on every non-refreshing request.
+    expect(tokens.bankAccountRef).toBe('bank-acc-ref-123')
     expect(getRefreshedQBToken).not.toHaveBeenCalled()
     expect(dbUpdates).toHaveLength(0)
   })
@@ -187,6 +192,9 @@ describe('getValidQbTokens', () => {
 
     expect(tokens.accessToken).toBe('fresh-access')
     expect(tokens.refreshToken).toBe('fresh-refresh')
+    // The refresh path already carried bankAccountRef through; pinned here
+    // alongside the fresh-token-path assertion above so both paths are guarded.
+    expect(tokens.bankAccountRef).toBe('bank-acc-ref-123')
     expect(getPortalConnection).toHaveBeenCalledExactlyOnceWith('portal-abc')
     expect(getRefreshedQBToken).toHaveBeenCalledExactlyOnceWith(
       'stored-refresh',
@@ -248,6 +256,7 @@ describe('getRefreshedQbTokenInfo', () => {
     const tokens = await getRefreshedQbTokenInfo('portal-abc')
 
     expect(tokens.accessToken).toBe('fresh-access')
+    expect(tokens.bankAccountRef).toBe('bank-acc-ref-123')
     expect(dbUpdates).toEqual([
       expect.objectContaining({ table: QBPortalConnection }),
     ])


### PR DESCRIPTION
Adds integration + unit coverage for the bank-deposit payout flow so CI exercises it, plus the shared test infra those tests depend on. Test-only — no source changes.

## Shared test infra
- `test/integration/setup.ts` — mock `QB_ACCOUNT_COLUMNS` on the `@/utils/intuitAPI` mock
- `test/helpers/mocks.ts` — `createDeposit` + account-status (`getAnAccount`/`updateAccount`) mocks
- `test/helpers/seed.ts` — `TEST_BANK_ACCOUNT_REF` + bank-account seeding on the portal connection

## Tests
- `payoutReconciliation/` — happy path + abort guards (refund line, negative fee, sum mismatch, duplicate/empty/unresolved line items), idempotent redelivery, flag-off no-op, inactive/deleted bank account, claim idempotency, invoice→QBO-payment resolution
- `paymentSucceeded/bankDepositFlagNoOp.test.ts` — `payment.succeeded` creates no per-payment deposit in batched mode
- `syncLog/staleReaperPayoutTerminal.test.ts` — stale PENDING payout claims flip to non-retryable
- `unit/utils/tokenRefresh.test.ts` — `bankAccountRef` carried on every token path
- `unit/type/settingRequestSchema.test.ts` + `setting/` — bank-account listing, invoice settings, request schema (OUT-4003)
- `test/fixtures/payout.webhook.ts` — payout webhook fixture

Excludes the local `captureWebhookEventGET` harness (`webhook/route.ts`, `webhook/webhook.controller.ts`) — a dev-only manual testing aid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)