### PR TITLE
OUT-3604: route paid-on-create payments through Undeposited Funds

### DIFF
--- a/src/app/api/quickbooks/invoice/invoice.service.ts
+++ b/src/app/api/quickbooks/invoice/invoice.service.ts
@@ -480,6 +480,21 @@ export class InvoiceService extends BaseService {
     return { value: serviceItemRef }
   }
 
+  // Batched-deposit mode routes the payment through Undeposited Funds so the
+  // payout deposit can later link and sweep it into the bank. Returns
+  // undefined when batching is off, letting QBO use its default account.
+  private async resolveDepositToAccountRef(
+    intuitApi: IntuitAPI,
+  ): Promise<string | undefined> {
+    const settingService = new SettingService(this.user)
+    const setting = await settingService.getOneByPortalId([
+      'bankDepositFeeFlag',
+    ])
+    return setting?.bankDepositFeeFlag
+      ? await intuitApi.getUndepositedFundsAccountId()
+      : undefined
+  }
+
   /**
    * Pre-flights QBO for invoices whose DocNumber starts with the Assembly
    * invoice number and returns the lowest free slot (`<n>`, `<n>-1`, …).
@@ -815,11 +830,20 @@ export class InvoiceService extends BaseService {
      */
     if (invoiceResource.status === InvoiceStatus.PAID) {
       const paymentService = new PaymentService(this.user)
+      // Same batched-deposit routing as invoice.paid: a paid-on-create
+      // payment must land in Undeposited Funds so the payout deposit can
+      // sweep it, otherwise it deposits straight to the bank and the batched
+      // deposit can't link it.
+      const depositToAccountRef =
+        await this.resolveDepositToAccountRef(intuitApiService)
       const qbPaymentPayload = {
         TotalAmt: totalWithTax,
         CustomerRef: {
           value: customerRefValue,
         },
+        ...(depositToAccountRef && {
+          DepositToAccountRef: { value: depositToAccountRef },
+        }),
         Line: [
           {
             Amount: totalWithTax,
@@ -915,21 +939,8 @@ export class InvoiceService extends BaseService {
 
     const invoiceAmount = Number(z.string().parse(invoiceLog.amount)) / 100
 
-    // Batched-deposit mode routes the payment through Undeposited Funds so the
-    // payout deposit can later link and sweep it into the bank.
-    const settingService = new SettingService(this.user)
-    const setting = await settingService.getOneByPortalId([
-      'absorbedFeeFlag',
-      'bankDepositFeeFlag',
-    ])
-    const useBankDepositFlow =
-      setting?.absorbedFeeFlag && setting?.bankDepositFeeFlag
-
     const intuitApi = new IntuitAPI(qbTokenInfo)
-
-    const depositToAccountRef = useBankDepositFlow
-      ? await intuitApi.getUndepositedFundsAccountId()
-      : undefined
+    const depositToAccountRef = await this.resolveDepositToAccountRef(intuitApi)
 
     const qbPaymentPayload = {
       TotalAmt: invoiceAmount,

--- a/src/utils/intuitAPI.ts
+++ b/src/utils/intuitAPI.ts
@@ -1052,18 +1052,32 @@ export default class IntuitAPI {
    * Queries by AccountSubType first (survives user renames), falls back to name.
    */
   async getUndepositedFundsAccountId(): Promise<string> {
+    CustomLogger.info({
+      message:
+        'IntuitAPI#getUndepositedFundsAccountId | Looking up Undeposited Funds account',
+    })
     const rawResult = await this.customQuery(
-      `SELECT Id FROM Account WHERE AccountSubType = 'UndepositedFunds' AND Active = true maxresults 1`,
+      `SELECT ${QB_ACCOUNT_COLUMNS.join(', ')} FROM Account WHERE AccountSubType = 'UndepositedFunds' AND Active = true maxresults 1`,
     )
     const undepositedAccount = QBAccountQueryResponseSchema.parse(
       rawResult ?? {},
     ).Account?.[0]
     if (undepositedAccount?.Id) {
+      CustomLogger.info({
+        obj: { account: undepositedAccount },
+        message:
+          'IntuitAPI#getUndepositedFundsAccountId | Found Undeposited Funds account',
+      })
       return undepositedAccount.Id
     }
 
     const byName = await this.getAnAccount('Undeposited Funds')
     if (byName?.Id) {
+      CustomLogger.info({
+        obj: { account: byName },
+        message:
+          'IntuitAPI#getUndepositedFundsAccountId | Found Undeposited Funds account by name',
+      })
       return byName.Id
     }
 


### PR DESCRIPTION
Fixes a gap in batched-deposit mode where an invoice arriving **already paid** could not be swept into its Stripe payout deposit.

## Problem
`webhookInvoiceCreated`'s paid branch creates the payment via `createPaymentAndSync`, which writes an `INVOICE/PAID` sync log with the QBO Payment ID — making that payment eligible for the payout reconciliation deposit (`getSuccessfulPaidPaymentIds` reads those logs). But unlike `webhookInvoicePaid`, the created-paid path omitted `DepositToAccountRef`, so the payment deposited straight to the bank. QBO can't link an already-deposited payment into a deposit, so the batched payout deposit would fail for any paid-on-create invoice.

## Changes
- Extract `resolveDepositToAccountRef` — returns the Undeposited Funds account when `bankDepositFeeFlag` is on, else `undefined` (QBO default). Used by **both** paid paths.
- `webhookInvoiceCreated` paid branch now sets `DepositToAccountRef` in batched mode.
- Decouple the routing from `absorbedFeeFlag` (now keyed on `bankDepositFeeFlag` alone), matching OUT-4003's dedicated toggle; drop the now-dead `absorbedFeeFlag` fetch.
- `getUndepositedFundsAccountId` selects `QB_ACCOUNT_COLUMNS` (was `SELECT Id`, which failed `QBAccountQueryResponseSchema` parse) + adds lookup logging.

## Follow-up
Integration coverage asserting `DepositToAccountRef` is set on the payment created by `webhookInvoiceCreated` when `bankDepositFeeFlag` is on is not yet added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)