### PR TITLE
OUT-4011: Name affected invoices in mixed-payout reconciliation notification

### DIFF
--- a/src/app/api/core/types/notification.ts
+++ b/src/app/api/core/types/notification.ts
@@ -25,12 +25,14 @@ export interface NotificationContext {
   entityType?: string
   eventType?: string
   entityKey?: string
-  invoiceNumber?: string
+  // Nullable string fields mirror their nullable qb_sync_logs columns, so
+  // callers can pass log values directly. Consumers treat null/undefined alike.
+  invoiceNumber?: string | null
   // Comma-joined invoice numbers for a multi-invoice failure (mixed payout),
   // where the single invoiceNumber above can't hold them all.
-  invoiceNumbers?: string
-  customerName?: string
-  productName?: string
-  qbItemName?: string
-  errorMessage?: string
+  invoiceNumbers?: string | null
+  customerName?: string | null
+  productName?: string | null
+  qbItemName?: string | null
+  errorMessage?: string | null
 }

--- a/src/app/api/core/types/notification.ts
+++ b/src/app/api/core/types/notification.ts
@@ -10,6 +10,7 @@ export enum NotificationActions {
   QB_TXN_LINK_FAILED = 'qb_txn_link_failed',
   QB_ITEM_INCOME_ACCOUNT_MISSING = 'qb_item_income_account_missing',
   QB_INVALID_ACCOUNT_TYPE = 'qb_invalid_account_type',
+  QB_PAYOUT_MIXED_INTENT = 'qb_payout_mixed_intent',
 }
 
 /**
@@ -25,6 +26,9 @@ export interface NotificationContext {
   eventType?: string
   entityKey?: string
   invoiceNumber?: string
+  // Comma-joined invoice numbers for a multi-invoice failure (mixed payout),
+  // where the single invoiceNumber above can't hold them all.
+  invoiceNumbers?: string
   customerName?: string
   productName?: string
   qbItemName?: string

--- a/src/app/api/notification/notification.helper.ts
+++ b/src/app/api/notification/notification.helper.ts
@@ -249,14 +249,14 @@ export const NotificationCopy: Record<
       const forInvoices = ctx?.invoiceNumbers
         ? ` for invoices ${ctx.invoiceNumbers}`
         : ''
-      return `A Stripe payout${ref} could not be recorded in QuickBooks because it mixes invoices set to batch into a bank deposit with invoices that are not — this happens when the bank-deposit setting changed between a payment and its payout. No deposit was created${forInvoices}, so nothing was double-booked. Record this payout's deposit manually in QuickBooks. This will not retry automatically.`
+      return `A Stripe payout${ref} could not be recorded in QuickBooks because it mixes invoices set to batch into a bank deposit with invoices that are not — this happens when the bank-deposit setting changed between a payment and its payout. No deposit was created${forInvoices}, so nothing was double-booked. Record this payout's deposit manually in QuickBooks. This will not be retried automatically.`
     },
     emailSubject: 'QuickBooks sync failed: payout needs manual reconciliation',
     emailBody: (ref, ctx) => {
       const forInvoices = ctx?.invoiceNumbers
         ? ` for invoices ${ctx.invoiceNumbers}`
         : ''
-      return `A Stripe payout${ref} could not be recorded in QuickBooks because it mixes invoices set to batch into a bank deposit with invoices that are not. This happens when the bank-deposit setting changed between a payment and its payout. No deposit was created${forInvoices}, so nothing was double-booked. Record this payout's deposit manually in QuickBooks. This payout will not retry automatically.`
+      return `A Stripe payout${ref} could not be recorded in QuickBooks because it mixes invoices set to batch into a bank deposit with invoices that are not. This happens when the bank-deposit setting changed between a payment and its payout. No deposit was created${forInvoices}, so nothing was double-booked. Record this payout's deposit manually in QuickBooks. This payout will not be retried automatically.`
     },
   },
 

--- a/src/app/api/notification/notification.helper.ts
+++ b/src/app/api/notification/notification.helper.ts
@@ -65,6 +65,9 @@ const describeAction = (entityType?: string, eventType?: string): string => {
   if (entityType === 'payment' && eventType === 'succeeded') {
     return 'invoice fees creation'
   }
+  if (entityType === 'payout' && eventType === 'settled') {
+    return 'payout reconciliation'
+  }
   const eventNoun =
     (
       {
@@ -234,6 +237,27 @@ export const NotificationCopy: Record<
     emailSubject: 'QuickBooks sync failed: item is missing an income account',
     emailBody: (ref) =>
       `A sync failed${ref} because a QuickBooks item has no income account assigned. This usually happens when the item was created in QuickBooks without an income account, or the account was removed afterwards. Open Products and Services in QuickBooks, edit the item, and set its income account. The next scheduled retry (within a few hours) will pick it up automatically.`,
+  },
+
+  // A Stripe payout straddled a bank-deposit setting change, so it contains
+  // both batched and non-batched invoices. We can't book one balanced deposit
+  // from a mix, so no deposit is created and the payout needs manual handling.
+  // Terminal — there is no scheduled retry for payouts.
+  [NotificationActions.QB_PAYOUT_MIXED_INTENT]: {
+    title: 'QuickBooks sync failed: payout needs manual reconciliation',
+    body: (ref, ctx) => {
+      const forInvoices = ctx?.invoiceNumbers
+        ? ` for invoices ${ctx.invoiceNumbers}`
+        : ''
+      return `A Stripe payout${ref} could not be recorded in QuickBooks because it mixes invoices set to batch into a bank deposit with invoices that are not — this happens when the bank-deposit setting changed between a payment and its payout. No deposit was created${forInvoices}, so nothing was double-booked. Record this payout's deposit manually in QuickBooks. This will not retry automatically.`
+    },
+    emailSubject: 'QuickBooks sync failed: payout needs manual reconciliation',
+    emailBody: (ref, ctx) => {
+      const forInvoices = ctx?.invoiceNumbers
+        ? ` for invoices ${ctx.invoiceNumbers}`
+        : ''
+      return `A Stripe payout${ref} could not be recorded in QuickBooks because it mixes invoices set to batch into a bank deposit with invoices that are not. This happens when the bank-deposit setting changed between a payment and its payout. No deposit was created${forInvoices}, so nothing was double-booked. Record this payout's deposit manually in QuickBooks. This payout will not retry automatically.`
+    },
   },
 
   [NotificationActions.QB_INVALID_ACCOUNT_TYPE]: {

--- a/src/app/api/quickbooks/syncLog/syncErrorNotifier.ts
+++ b/src/app/api/quickbooks/syncLog/syncErrorNotifier.ts
@@ -5,7 +5,10 @@ import {
   NotificationContext,
 } from '@/app/api/core/types/notification'
 import { NotificationService } from '@/app/api/notification/notification.service'
-import { UserActionableErrorCodes } from '@/constant/intuitErrorCode'
+import {
+  AppActionableErrorCodes,
+  UserActionableErrorCodes,
+} from '@/constant/intuitErrorCode'
 import { QBSyncLogSelectSchemaType } from '@/db/schema/qbSyncLogs'
 import { getPortalConnection } from '@/db/service/token.service'
 
@@ -18,7 +21,11 @@ export function getActionForErrorCode(
   errorCode: string | null | undefined,
 ): NotificationActions | null {
   if (!errorCode) return null
-  return UserActionableErrorCodes[errorCode] ?? null
+  return (
+    UserActionableErrorCodes[errorCode] ??
+    AppActionableErrorCodes[errorCode] ??
+    null
+  )
 }
 
 /**
@@ -71,6 +78,12 @@ export class SyncErrorNotifier extends BaseService {
       productName: log.productName ?? undefined,
       qbItemName: log.qbItemName ?? undefined,
       errorMessage: log.errorMessage ?? undefined,
+      // Mixed-payout rows stash the affected invoice numbers in `remark`; surface
+      // them for the body while copilotId stays the ref.
+      invoiceNumbers:
+        action === NotificationActions.QB_PAYOUT_MIXED_INTENT
+          ? (log.remark ?? undefined)
+          : undefined,
     }
     const portal = await getPortalConnection(this.user.workspaceId)
 

--- a/src/app/api/quickbooks/syncLog/syncErrorNotifier.ts
+++ b/src/app/api/quickbooks/syncLog/syncErrorNotifier.ts
@@ -73,16 +73,16 @@ export class SyncErrorNotifier extends BaseService {
       entityType: log.entityType,
       eventType: log.eventType,
       entityKey: getEntityKey(log),
-      invoiceNumber: log.invoiceNumber ?? undefined,
-      customerName: log.customerName ?? undefined,
-      productName: log.productName ?? undefined,
-      qbItemName: log.qbItemName ?? undefined,
-      errorMessage: log.errorMessage ?? undefined,
+      invoiceNumber: log.invoiceNumber,
+      customerName: log.customerName,
+      productName: log.productName,
+      qbItemName: log.qbItemName,
+      errorMessage: log.errorMessage,
       // Mixed-payout rows stash the affected invoice numbers in `remark`; surface
       // them for the body while copilotId stays the ref.
       invoiceNumbers:
         action === NotificationActions.QB_PAYOUT_MIXED_INTENT
-          ? (log.remark ?? undefined)
+          ? log.remark
           : undefined,
     }
     const portal = await getPortalConnection(this.user.workspaceId)

--- a/src/app/api/quickbooks/syncLog/syncLog.service.ts
+++ b/src/app/api/quickbooks/syncLog/syncLog.service.ts
@@ -388,7 +388,12 @@ export class SyncLogService extends BaseService {
    */
   async getSuccessfulPaidPaymentIds(
     copilotInvoiceIds: string[],
-  ): Promise<Map<string, { paymentId: string; isBatchedDeposit: boolean }>> {
+  ): Promise<
+    Map<
+      string,
+      { paymentId: string; isBatchedDeposit: boolean; invoiceNumber: string }
+    >
+  > {
     if (copilotInvoiceIds.length === 0) return new Map()
 
     const rows = await this.db
@@ -396,6 +401,7 @@ export class SyncLogService extends BaseService {
         copilotId: QBSyncLog.copilotId,
         quickbooksId: QBSyncLog.quickbooksId,
         isBatchedDeposit: QBInvoiceSync.isBatchedDeposit,
+        invoiceNumber: QBSyncLog.invoiceNumber,
       })
       .from(QBSyncLog)
       .innerJoin(
@@ -419,13 +425,14 @@ export class SyncLogService extends BaseService {
 
     const paymentIdByInvoice = new Map<
       string,
-      { paymentId: string; isBatchedDeposit: boolean }
+      { paymentId: string; isBatchedDeposit: boolean; invoiceNumber: string }
     >()
     for (const row of rows) {
       if (row.quickbooksId)
         paymentIdByInvoice.set(row.copilotId, {
           paymentId: row.quickbooksId,
           isBatchedDeposit: row.isBatchedDeposit,
+          invoiceNumber: row.invoiceNumber ?? '',
         })
     }
     return paymentIdByInvoice

--- a/src/app/api/quickbooks/webhook/webhook.service.ts
+++ b/src/app/api/quickbooks/webhook/webhook.service.ts
@@ -36,7 +36,13 @@ import { addSyncBreadcrumb } from '@/utils/sentry'
 import { and, eq } from 'drizzle-orm'
 import httpStatus from 'http-status'
 import { AccountTypeObj } from '@/constant/qbConnection'
+import { PAYOUT_MIXED_INTENT_CODE } from '@/constant/intuitErrorCode'
 import { TokenService } from '@/app/api/quickbooks/token/token.service'
+
+// A payout that mixes batched and non-batched invoices. Thrown so the single
+// FAILED-log write in the catch can tag it with the routable sentinel code
+// (a plain APIError would land as "400" and skip the IU notification).
+class MixedPayoutIntentError extends Error {}
 
 export class WebhookService extends BaseService {
   async handleWebhookEvent(
@@ -726,8 +732,7 @@ export class WebhookService extends BaseService {
         (id) => paymentIdByInvoice.get(id)?.isBatchedDeposit,
       )
       if (!allBatched) {
-        throw new APIError(
-          httpStatus.BAD_REQUEST,
+        throw new MixedPayoutIntentError(
           `Payout ${payoutId} mixes batched and non-batched invoices; unsupported`,
         )
       }
@@ -802,7 +807,18 @@ export class WebhookService extends BaseService {
         message: 'Payout reconciliation handler failed',
         obj: error,
       })
+      const isMixed = error instanceof MixedPayoutIntentError
       const errorWithCode = getMessageAndCodeFromError(error)
+      // Mixed intent stashes the affected invoice numbers in `remark` (a payout
+      // spans multiple invoices, so they don't fit the single invoiceNumber col).
+      const affectedInvoiceNumbers = copilotInvoiceIds
+        .map((id) => paymentIdByInvoice.get(id)?.invoiceNumber)
+        .filter(Boolean)
+        .join(', ')
+      // Single FAILED-log write. Mixed intent gets the routable sentinel so
+      // SyncErrorNotifier alerts IUs; everything else keeps its derived code.
+      // No qbItemName — it would outrank copilotId (the payout id) in the
+      // notification's entity reference.
       await syncLogService.updateOrCreateQBSyncLog({
         portalId: this.user.workspaceId,
         entityType: EntityType.PAYOUT,
@@ -811,14 +827,19 @@ export class WebhookService extends BaseService {
         copilotId: payoutId,
         amount: payout.netAmount.toFixed(2),
         feeAmount: feeCents.toFixed(2),
-        remark: 'Stripe payout batched deposit',
-        qbItemName: 'Stripe payout',
+        remark:
+          isMixed && affectedInvoiceNumbers
+            ? affectedInvoiceNumbers
+            : 'Stripe payout batched deposit',
         errorMessage: errorWithCode.message,
-        errorCode: errorWithCode.code?.toString(),
-        // Terminal: no PAYOUT resync path yet, so retrying only burns
-        // attempts to a misleading alert. Recovery is manual for now.
+        errorCode: isMixed
+          ? PAYOUT_MIXED_INTENT_CODE
+          : errorWithCode.code?.toString(),
+        // Terminal: no PAYOUT resync path, so retrying only burns attempts.
         shouldRetry: false,
-        category: getCategory(errorWithCode),
+        category: isMixed
+          ? FailedRecordCategoryType.OTHERS
+          : getCategory(errorWithCode),
       })
       console.error(
         `WebhookService#handlePayoutReconciliationCompleted :: Error | Portal Id: ${this.user.workspaceId} | Payout: ${payoutId}`,

--- a/src/constant/intuitErrorCode.ts
+++ b/src/constant/intuitErrorCode.ts
@@ -57,3 +57,14 @@ export const UserActionableErrorCodes: Record<string, NotificationActions> = {
   [QBOErrorCodes.DEPOSITED_TXN_LOCKED]:
     NotificationActions.QB_DEPOSITED_TXN_LOCKED,
 }
+
+// App-level sentinel error code for a payout that mixes batched and
+// non-batched invoices — not a QBO code, so it lives outside the registry
+// above. Written to qb_sync_logs.error_code so SyncErrorNotifier routes it.
+export const PAYOUT_MIXED_INTENT_CODE = 'payout_mixed_intent'
+
+// App-level (non-QBO) sentinel codes routed to IU notifications, consulted by
+// getActionForErrorCode alongside UserActionableErrorCodes.
+export const AppActionableErrorCodes: Record<string, NotificationActions> = {
+  [PAYOUT_MIXED_INTENT_CODE]: NotificationActions.QB_PAYOUT_MIXED_INTENT,
+}

--- a/test/helpers/mocks.ts
+++ b/test/helpers/mocks.ts
@@ -71,6 +71,9 @@ export function createMockCopilotAPI(overrides: CopilotAPIOverrides = {}) {
       id: TEST_COPILOT_INVOICE_ID,
       number: TEST_INVOICE_NUMBER,
     }),
+    // Deferred SyncErrorNotifier dispatch calls these; empty IU list = no-op.
+    getInternalUsers: vi.fn().mockResolvedValue({ data: [] }),
+    createNotification: vi.fn().mockResolvedValue({ id: 'notif-1' }),
     ...overrides,
   }
 }
@@ -153,9 +156,6 @@ export function createMockIntuitAPI(overrides: IntuitAPIOverrides = {}) {
     }),
     createPurchase: vi.fn().mockResolvedValue({
       Purchase: { Id: TEST_QB_PURCHASE_ID, SyncToken: '0' },
-    }),
-    createDeposit: vi.fn().mockResolvedValue({
-      Deposit: { Id: 'qb-deposit-1', SyncToken: '0' },
     }),
     deletePurchase: vi.fn().mockResolvedValue({
       Purchase: { Id: TEST_QB_PURCHASE_ID, status: 'Deleted' },

--- a/test/integration/quickbooks/invoiceVoided/qbVoidStaleObject.test.ts
+++ b/test/integration/quickbooks/invoiceVoided/qbVoidStaleObject.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest'
+import { and, eq } from 'drizzle-orm'
+
+import { db } from '@/db'
+import { QBSyncLog } from '@/db/schema/qbSyncLogs'
+import { EntityType, EventType, LogStatus } from '@/app/api/core/types/log'
+import { QBOErrorCodes } from '@/constant/intuitErrorCode'
+import { HttpFetchError } from '@/utils/error'
+
+import { invoiceVoidedPayload } from '@test/fixtures/invoiceVoided.webhook'
+import {
+  seedHealthyPortal,
+  seedQBCustomer,
+  seedQBInvoiceSync,
+  seedInvoiceCreatedLog,
+  TEST_COPILOT_INVOICE_ID,
+} from '@test/helpers/seed'
+import { createMockIntuitAPI } from '@test/helpers/mocks'
+import { setupInvoiceVoidedTest } from '@test/helpers/invoiceVoidedTestSetup'
+import { postWebhook } from '@test/helpers/webhook'
+
+// Invoice voided out-of-band in QBO leaves our row OPEN, so the void hits a
+// stale SyncToken → 5010 → FAILED with error_code=5010 (routes to QB_STALE_OBJECT).
+describe('POST /api/quickbooks/webhook — invoice.voided (QBO returns 5010 stale object)', () => {
+  const apis = setupInvoiceVoidedTest(() => ({
+    intuit: createMockIntuitAPI({
+      voidInvoice: vi.fn().mockRejectedValue(
+        new HttpFetchError({
+          status: 400,
+          statusText: 'Bad Request',
+          url: 'https://quickbooks.api.intuit.com/v3/company/realm/invoice',
+          body: {
+            Fault: {
+              Error: [
+                {
+                  code: String(QBOErrorCodes.STALE_OBJECT),
+                  Message: 'Stale Object Error',
+                  Detail:
+                    'Stale Object Error : You and quickbooks-sync were working on this at the same time.',
+                },
+              ],
+              type: 'ValidationFault',
+            },
+          },
+        }),
+      ),
+    }),
+  }))
+
+  it('marks the voided log FAILED with error_code 5010 (routes to QB_STALE_OBJECT)', async () => {
+    await seedHealthyPortal()
+    const customer = await seedQBCustomer()
+    await seedQBInvoiceSync({ customerId: customer.id }) // defaults to OPEN
+    await seedInvoiceCreatedLog()
+
+    const res = await postWebhook(invoiceVoidedPayload)
+    expect(res.status).toBe(200)
+
+    const [voidedLog] = await db
+      .select()
+      .from(QBSyncLog)
+      .where(
+        and(
+          eq(QBSyncLog.copilotId, TEST_COPILOT_INVOICE_ID),
+          eq(QBSyncLog.eventType, EventType.VOIDED),
+        ),
+      )
+    expect(voidedLog.entityType).toBe(EntityType.INVOICE)
+    expect(voidedLog.status).toBe(LogStatus.FAILED)
+    // The QBO fault code must survive as error_code to route to QB_STALE_OBJECT.
+    expect(voidedLog.errorCode).toBe(String(QBOErrorCodes.STALE_OBJECT))
+
+    expect(apis.intuit.voidInvoice).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/integration/quickbooks/payoutReconciliation/mixed.test.ts
+++ b/test/integration/quickbooks/payoutReconciliation/mixed.test.ts
@@ -5,6 +5,7 @@ import { db } from '@/db'
 import { QBSyncLog } from '@/db/schema/qbSyncLogs'
 import { EntityType, EventType, LogStatus } from '@/app/api/core/types/log'
 
+import { PAYOUT_MIXED_INTENT_CODE } from '@/constant/intuitErrorCode'
 import { payoutPayload } from '@test/fixtures/payout.webhook'
 import {
   seedHealthyPortal,
@@ -53,5 +54,13 @@ describe('payout — invoices froze a mix of batched and non-batched', () => {
     expect(payoutLog.status).toBe(LogStatus.FAILED)
     expect(payoutLog.shouldRetry).toBe(false)
     expect(payoutLog.errorMessage).toContain('mixes batched and non-batched')
+    // Routable sentinel so SyncErrorNotifier notifies IUs for manual reconciliation.
+    expect(payoutLog.errorCode).toBe(PAYOUT_MIXED_INTENT_CODE)
+    // No qbItemName: it would outrank copilotId in the notification's entity
+    // reference, hiding which payout to reconcile.
+    expect(payoutLog.qbItemName).toBeNull()
+    // remark carries the affected invoice numbers so the IU notification can
+    // name which invoices went unrecorded.
+    expect(payoutLog.remark).toBe('INV-A, INV-B')
   })
 })

--- a/test/integration/quickbooks/payoutReconciliation/resolvePayments.test.ts
+++ b/test/integration/quickbooks/payoutReconciliation/resolvePayments.test.ts
@@ -59,6 +59,7 @@ describe('SyncLogService.getSuccessfulPaidPaymentIds', () => {
     expect(result.get('inv_a')).toEqual({
       paymentId: 'qbpay_a',
       isBatchedDeposit: true,
+      invoiceNumber: 'INV-A',
     })
     expect(result.has('inv_b')).toBe(false) // FAILED excluded
     expect(result.has('inv_c')).toBe(false) // other portal excluded

--- a/test/unit/notification/notification.helper.test.ts
+++ b/test/unit/notification/notification.helper.test.ts
@@ -82,6 +82,38 @@ describe('getInProductNotificationDetail', () => {
     expect(detail.body).not.toContain('payment completion')
   })
 
+  it('renders payout reconciliation with the payout id as ref and names the affected invoices', () => {
+    const ctx: NotificationContext = {
+      entityType: 'payout',
+      eventType: 'settled',
+      entityKey: 'po_test_1',
+      invoiceNumbers: 'INV-A, INV-B',
+    }
+    const detail = getInProductNotificationDetail(
+      NotificationActions.QB_PAYOUT_MIXED_INTENT,
+      ctx,
+    )
+    expect(detail.body).toContain('during payout reconciliation, ref po_test_1')
+    expect(detail.body).not.toContain('ref Stripe payout')
+    expect(detail.body).toContain(
+      'No deposit was created for invoices INV-A, INV-B',
+    )
+  })
+
+  it('omits the invoice list from the payout body when no invoice numbers are present', () => {
+    const ctx: NotificationContext = {
+      entityType: 'payout',
+      eventType: 'settled',
+      entityKey: 'po_test_1',
+    }
+    const detail = getInProductNotificationDetail(
+      NotificationActions.QB_PAYOUT_MIXED_INTENT,
+      ctx,
+    )
+    expect(detail.body).toContain('No deposit was created, so nothing')
+    expect(detail.body).not.toContain('for invoices')
+  })
+
   it('5010 (invoice-only after suppression) warns that the failure is final', () => {
     const ctx: NotificationContext = {
       entityType: 'invoice',

--- a/test/unit/quickbooks/syncErrorNotifier.test.ts
+++ b/test/unit/quickbooks/syncErrorNotifier.test.ts
@@ -42,9 +42,15 @@ import {
   getEntityKey,
 } from '@/app/api/quickbooks/syncLog/syncErrorNotifier'
 import {
+  AppActionableErrorCodes,
+  PAYOUT_MIXED_INTENT_CODE,
   QBOErrorCodes,
   UserActionableErrorCodes,
 } from '@/constant/intuitErrorCode'
+import {
+  getIEmailNotificationDetail,
+  getInProductNotificationDetail,
+} from '@/app/api/notification/notification.helper'
 
 const baseLog: QBSyncLogSelectSchemaType = {
   id: 'log-1',
@@ -70,6 +76,7 @@ const baseLog: QBSyncLogSelectSchemaType = {
   errorCode: String(QBOErrorCodes.CLOSED_PERIOD),
   category: 'qb_api_error' as never,
   attempt: 0,
+  shouldRetry: true,
   createdAt: new Date(),
   updatedAt: new Date(),
   deletedAt: null,
@@ -81,6 +88,14 @@ describe('getActionForErrorCode', () => {
   // mapping change here will fail this test loudly.
   it.each(Object.entries(UserActionableErrorCodes))(
     'maps registry code %s to action %s',
+    (code, expectedAction) => {
+      expect(getActionForErrorCode(code)).toBe(expectedAction)
+    },
+  )
+
+  // Self-extending over the app-level sentinel registry, mirroring the QBO one.
+  it.each(Object.entries(AppActionableErrorCodes))(
+    'maps app sentinel code %s to action %s',
     (code, expectedAction) => {
       expect(getActionForErrorCode(code)).toBe(expectedAction)
     },
@@ -222,6 +237,43 @@ describe('SyncErrorNotifier#notify', () => {
       expect(action).toBe(NotificationActions.QB_STALE_OBJECT)
     },
   )
+
+  it('dispatches the mixed-payout notification for a FAILED payout with the sentinel code', async () => {
+    const notifier = new SyncErrorNotifier(user)
+
+    await notifier.notify({
+      ...baseLog,
+      entityType: 'payout' as never,
+      eventType: 'settled' as never,
+      errorCode: PAYOUT_MIXED_INTENT_CODE,
+      quickbooksId: null,
+      invoiceNumber: null,
+      copilotId: 'po_test_1',
+      // Webhook stashes the affected invoice numbers in remark for this action.
+      remark: 'INV-A, INV-B',
+      errorMessage:
+        'Payout po_test_1 mixes batched and non-batched invoices; unsupported',
+    })
+
+    expect(sendNotificationToIU).toHaveBeenCalledTimes(1)
+    const [, action, ctx] = sendNotificationToIU.mock.calls[0]
+    expect(action).toBe(NotificationActions.QB_PAYOUT_MIXED_INTENT)
+    // copilotId stays the ref; the invoice list rides in invoiceNumbers.
+    expect(ctx).toMatchObject({
+      entityType: 'payout',
+      entityKey: 'po_test_1',
+      invoiceNumbers: 'INV-A, INV-B',
+    })
+
+    // Close the seam: the ctx extracted from `remark` must render the invoice
+    // list in the real copy (both channels), with the payout id as the ref.
+    const inProduct = getInProductNotificationDetail(action, ctx)
+    const email = getIEmailNotificationDetail(action, ctx)
+    for (const body of [inProduct.body, email.body]) {
+      expect(body).toContain('ref po_test_1')
+      expect(body).toContain('No deposit was created for invoices INV-A, INV-B')
+    }
+  })
 
   it('dispatches a notification for a FAILED row with a user-actionable code', async () => {
     const notifier = new SyncErrorNotifier(user)


### PR DESCRIPTION
## Summary

When a Stripe payout mixes invoices set to batch into a bank deposit with invoices that are not, no deposit can be booked and the payout needs manual reconciliation. This surfaces that case to internal users as a `QB_PAYOUT_MIXED_INTENT` notification, and — the focus of this branch — **names the specific invoice numbers** in the notification body so it's clear which invoices went unrecorded.

## What changed

- **Notification declarations** — `PAYOUT_MIXED_INTENT_CODE` sentinel + `AppActionableErrorCodes` routing, an `invoiceNumbers` context field, and the `QB_PAYOUT_MIXED_INTENT` in-product/email copy that lists the affected invoices.
- **Service logic** — the webhook detects mixed intent (`MixedPayoutIntentError`), writes a single terminal FAILED sync-log row tagged with the sentinel, and stashes the affected invoice numbers in `remark` (a payout spans multiple invoices, so they don't fit the single `invoice_number` column — no schema change). `getSuccessfulPaidPaymentIds` returns each invoice number; `SyncErrorNotifier` surfaces the list while keeping the payout id as the entity reference.

## Design notes

- No DB migration: `remark` is an existing free-text column; only the value written for the mixed-payout FAILED case changed.
- The payout id stays as the notification "ref" for support traceability; the invoice list is an added clause, not a replacement.

## Testing

- New/updated coverage: mixed-payout persists invoice numbers to `remark`, `resolvePayments` returns them, the notifier renders the invoice list through the real copy (both channels), and a regression test for `invoice.voided` on an OPEN row surfacing a QBO **5010** as `error_code` → `QB_STALE_OBJECT`.
- Full suite green: **64 unit + 101 integration** tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
