### PR TITLE
OUT-4012: warn before changing the bank-deposit flag

### DIFF
--- a/src/components/dashboard/settings/SettingAccordion.tsx
+++ b/src/components/dashboard/settings/SettingAccordion.tsx
@@ -3,6 +3,7 @@ import InvoiceDetail from '@/components/dashboard/settings/sections/invoice/Invo
 import AccountMapping from '@/components/dashboard/settings/sections/account/AccountMapping'
 import ProductMapping from '@/components/dashboard/settings/sections/product/ProductMapping'
 import Accordion from '@/components/ui/Accordion'
+import ConfirmModal from '@/components/ui/ConfirmModal'
 import Divider from '@/components/ui/Divider'
 import {
   useInvoiceDetailSettings,
@@ -39,7 +40,6 @@ export default function SettingAccordion({
 
   const {
     settingState,
-    submitInvoiceSettings,
     cancelInvoiceSettings,
     isLoading,
     changeSettings,
@@ -47,6 +47,10 @@ export default function SettingAccordion({
     bankAccountOptions,
     bankAccountsError,
     canSave,
+    showBankDepositWarning,
+    requestInvoiceSettingsSave,
+    confirmBankDepositChange,
+    cancelBankDepositChange,
   } = useInvoiceDetailSettings()
 
   const {
@@ -172,7 +176,7 @@ export default function SettingAccordion({
                       variant="primary"
                       prefixIcon="Check"
                       disabled={!canSave}
-                      onClick={submitInvoiceSettings}
+                      onClick={requestInvoiceSettingsSave}
                     />
                   </>
                 )}
@@ -202,6 +206,13 @@ export default function SettingAccordion({
           </div>
         )
       })}
+      <ConfirmModal
+        open={showBankDepositWarning}
+        title="Change bank deposit setting?"
+        description="This applies only to invoices created from now on; existing invoices are unaffected. If a Stripe payout mixes invoices from before and after the change, you'll need to reconcile that payout manually in QuickBooks."
+        onConfirm={confirmBankDepositChange}
+        onCancel={cancelBankDepositChange}
+      />
     </div>
   )
 }

--- a/src/components/ui/ConfirmModal.tsx
+++ b/src/components/ui/ConfirmModal.tsx
@@ -25,24 +25,28 @@ export default function ConfirmModal({
   const titleId = useId()
   const descId = useId()
   const dialogRef = useRef<HTMLDivElement>(null)
-  // Keep the latest onCancel without re-running the focus effect each render.
-  const onCancelRef = useRef(onCancel)
-  onCancelRef.current = onCancel
 
-  // On open: focus into the dialog, trap Tab, and restore focus on close.
+  // On open, focus into the dialog; on close, restore focus to the opener.
   useEffect(() => {
     if (!open) return
     const previouslyFocused = document.activeElement as HTMLElement | null
-    const focusables = Array.from(
-      dialogRef.current?.querySelectorAll<HTMLElement>('button') ?? [],
-    )
-    focusables[0]?.focus()
+    const buttons = dialogRef.current?.querySelectorAll<HTMLElement>('button')
+    buttons?.[0]?.focus()
+    return () => previouslyFocused?.focus()
+  }, [open])
 
+  // Escape cancels; Tab is trapped between the dialog's buttons.
+  useEffect(() => {
+    if (!open) return
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') return onCancelRef.current()
-      if (e.key !== 'Tab' || focusables.length === 0) return
-      const first = focusables[0]
-      const last = focusables[focusables.length - 1]
+      if (e.key === 'Escape') return onCancel()
+      if (e.key !== 'Tab') return
+      const buttons = Array.from(
+        dialogRef.current?.querySelectorAll<HTMLElement>('button') ?? [],
+      )
+      if (buttons.length === 0) return
+      const first = buttons[0]
+      const last = buttons[buttons.length - 1]
       if (e.shiftKey && document.activeElement === first) {
         e.preventDefault()
         last.focus()
@@ -52,11 +56,8 @@ export default function ConfirmModal({
       }
     }
     document.addEventListener('keydown', onKeyDown)
-    return () => {
-      document.removeEventListener('keydown', onKeyDown)
-      previouslyFocused?.focus()
-    }
-  }, [open])
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [open, onCancel])
 
   if (!open) return null
 

--- a/src/components/ui/ConfirmModal.tsx
+++ b/src/components/ui/ConfirmModal.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useEffect, useId } from 'react'
+import { useEffect, useId, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { Button } from 'copilot-design-system'
 
@@ -24,16 +24,39 @@ export default function ConfirmModal({
 }: ConfirmModalProps) {
   const titleId = useId()
   const descId = useId()
+  const dialogRef = useRef<HTMLDivElement>(null)
+  // Keep the latest onCancel without re-running the focus effect each render.
+  const onCancelRef = useRef(onCancel)
+  onCancelRef.current = onCancel
 
-  // Wire Escape-to-cancel while open.
+  // On open: focus into the dialog, trap Tab, and restore focus on close.
   useEffect(() => {
     if (!open) return
+    const previouslyFocused = document.activeElement as HTMLElement | null
+    const focusables = Array.from(
+      dialogRef.current?.querySelectorAll<HTMLElement>('button') ?? [],
+    )
+    focusables[0]?.focus()
+
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onCancel()
+      if (e.key === 'Escape') return onCancelRef.current()
+      if (e.key !== 'Tab' || focusables.length === 0) return
+      const first = focusables[0]
+      const last = focusables[focusables.length - 1]
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first.focus()
+      }
     }
     document.addEventListener('keydown', onKeyDown)
-    return () => document.removeEventListener('keydown', onKeyDown)
-  }, [open, onCancel])
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+      previouslyFocused?.focus()
+    }
+  }, [open])
 
   if (!open) return null
 
@@ -43,6 +66,7 @@ export default function ConfirmModal({
       onClick={onCancel}
     >
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}

--- a/src/components/ui/ConfirmModal.tsx
+++ b/src/components/ui/ConfirmModal.tsx
@@ -1,0 +1,67 @@
+'use client'
+import { useEffect, useId } from 'react'
+import { createPortal } from 'react-dom'
+import { Button } from 'copilot-design-system'
+
+type ConfirmModalProps = {
+  open: boolean
+  title: string
+  description: string
+  confirmLabel?: string
+  cancelLabel?: string
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export default function ConfirmModal({
+  open,
+  title,
+  description,
+  confirmLabel = 'Continue',
+  cancelLabel = 'Cancel',
+  onConfirm,
+  onCancel,
+}: ConfirmModalProps) {
+  const titleId = useId()
+  const descId = useId()
+
+  // Wire Escape-to-cancel while open.
+  useEffect(() => {
+    if (!open) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel()
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [open, onCancel])
+
+  if (!open) return null
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={onCancel}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descId}
+        className="mx-4 w-full max-w-sm rounded-lg bg-white p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id={titleId} className="mb-2 text-base font-semibold">
+          {title}
+        </h2>
+        <p id={descId} className="mb-6 text-sm text-gray-600">
+          {description}
+        </p>
+        <div className="flex justify-end gap-2">
+          <Button label={cancelLabel} variant="text" onClick={onCancel} />
+          <Button label={confirmLabel} variant="primary" onClick={onConfirm} />
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/src/hook/useSettings.ts
+++ b/src/hook/useSettings.ts
@@ -442,6 +442,7 @@ export const useInvoiceDetailSettings = () => {
     initialInvoiceSetting,
   )
   const [showButton, setShowButton] = useState(false)
+  const [showBankDepositWarning, setShowBankDepositWarning] = useState(false)
   const [intialSettingState, setIntialSettingState] = useState<
     InvoiceSettingType | undefined
   >()
@@ -522,10 +523,29 @@ export const useInvoiceDetailSettings = () => {
     setSettingState(intialSettingState || initialInvoiceSetting)
   }
 
+  // Warn only when the bank-deposit flag actually changed vs the saved value.
+  const bankDepositFlagChanged =
+    !!intialSettingState &&
+    settingState.bankDepositFeeFlag !== intialSettingState.bankDepositFeeFlag
+
+  const requestInvoiceSettingsSave = () => {
+    if (bankDepositFlagChanged) {
+      setShowBankDepositWarning(true)
+      return
+    }
+    submitInvoiceSettings()
+  }
+
+  const confirmBankDepositChange = () => {
+    setShowBankDepositWarning(false)
+    submitInvoiceSettings()
+  }
+
+  const cancelBankDepositChange = () => setShowBankDepositWarning(false)
+
   return {
     settingState,
     changeSettings,
-    submitInvoiceSettings,
     cancelInvoiceSettings,
     error,
     isLoading,
@@ -533,6 +553,10 @@ export const useInvoiceDetailSettings = () => {
     bankAccountOptions,
     bankAccountsError,
     canSave,
+    showBankDepositWarning,
+    requestInvoiceSettingsSave,
+    confirmBankDepositChange,
+    cancelBankDepositChange,
   }
 }
 


### PR DESCRIPTION
## Problem

Changing `bankDepositFeeFlag` has consequences users can't see: the deposit behavior is frozen per invoice at creation, so a toggle only affects new invoices, and a Stripe payout that mixes pre/post-change invoices won't get its automatic bank deposit and needs manual reconciliation.

## Shipped

A confirmation modal on **save** (not on toggle), shown only when the flag differs from its saved value — covers both enable and disable, and never fires when unchanged. UX safeguard only; correctness lives in the frozen-intent + mixed-guard work (OUT-4010/4009).

Copy:
> **Change bank deposit setting?**
> This applies only to invoices created from now on; existing invoices are unaffected. If a Stripe payout mixes invoices from before and after the change, you'll need to reconcile that payout manually in QuickBooks.

## Code sites

- `src/components/ui/ConfirmModal.tsx` *(new)* — reusable portal modal (Escape/backdrop dismiss, `role="dialog"` + `aria-labelledby`/`aria-describedby` via `useId`).
- `src/hook/useSettings.ts` — `useInvoiceDetailSettings` gains the save-intercept (`requestInvoiceSettingsSave` / `confirmBankDepositChange` / `cancelBankDepositChange`); raw `submitInvoiceSettings` no longer exported.
- `src/components/dashboard/settings/SettingAccordion.tsx` — invoice save button routes through the guard and renders the modal. `InvoiceDetail.tsx` unchanged (checkbox stays a free local toggle).

## Notes

- Stacked on **OUT-4011** (base branch), not master.
- No component-test infra exists in the repo (both Vitest projects run `environment: 'node'`); verified via `tsc`, lint, prettier, `yarn build`, and `yarn test` (357/357).
- Known follow-up: on a brand-new portal's first-time setup, enabling the flag trips the modal (saved value genuinely changed) — cosmetic, suppression deferred pending a product call.

## Testing Criteria

<img width="1050" height="641" alt="image" src="https://github.com/user-attachments/assets/3671bd19-f2ee-4d9b-9bc7-07a9c2157dd0" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)